### PR TITLE
refactor: have form generated and driven by hydra operation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "packages": [
-    "api"
+    "api",
+    "ui"
   ],
   "version": "independent",
   "command": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -958,6 +958,11 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hydrofoil/alcaeus-forms": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@hydrofoil/alcaeus-forms/-/alcaeus-forms-0.1.0.tgz",
+      "integrity": "sha512-W8afkcWoys0rznfWXnnlxNN2gmEnNABgzLltsDIga/wTC2Q2B/2yWpBP2J3XmrvhwRDDJ9YSwquONuXMKOCXzQ=="
+    },
     "@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz",
@@ -967,6 +972,19 @@
         "cssnano": "^4.0.0",
         "cssnano-preset-default": "^4.0.0",
         "postcss": "^7.0.0"
+      }
+    },
+    "@lit-any/core": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@lit-any/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-hYUszPCWvu34RYF9MbSPxUOMoD9d7V7gFYGouTyVLI5y6S25v8agZE3Z6ieMV4WM0GY5sD03Zb0oh7cIoRYxfA=="
+    },
+    "@lit-any/forms": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@lit-any/forms/-/forms-0.10.1.tgz",
+      "integrity": "sha512-9GeG5crZSKHIxSjPCcA/C0rWjVB8YREU+qhHelkpnXdsQcSIAFhkGyd//JdTUqkzOXWVGAWn+aejboBF2VSL4w==",
+      "requires": {
+        "@lit-any/core": "^0.9.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -10292,6 +10310,19 @@
           "dev": true
         }
       }
+    },
+    "lit-element": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.2.1.tgz",
+      "integrity": "sha512-ipDcgQ1EpW6Va2Z6dWm79jYdimVepO5GL0eYkZrFvdr0OD/1N260Q9DH+K5HXHFrRoC7dOg+ZpED2XE0TgGdXw==",
+      "requires": {
+        "lit-html": "^1.0.0"
+      }
+    },
+    "lit-html": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
+      "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
     },
     "load-json-file": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,9 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@hydrofoil/alcaeus-forms": "^0.1.0",
+    "@lit-any/forms": "^0.10.1",
+    "lit-element": "^2.2.1",
     "@zazuko/rdf-vocabularies": "2019.10.22",
     "alcaeus": "0.9.2",
     "buefy": "0.8.5",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -17,7 +17,7 @@ const PROP_NAME = expand('schema:name')
 const API_PROJECTS = expand('dataCube:api/projects')
 const API_SOURCES = expand('dataCube:api/sources')
 const OP_PROJECTS_GET = expand('dataCube:api/GetDataCubeProjects')
-const OP_PROJECTS_CREATE = expand('dataCube:api/CreateProject')
+export const OP_PROJECTS_CREATE = expand('dataCube:api/CreateProject')
 const OP_SOURCES_CREATE = expand('dataCube:api/AddSource')
 
 type Constructor<T = {}> = new (...args: any[]) => HydraResource;
@@ -117,12 +117,12 @@ class ProjectsClient {
     return projectsCollection.members || []
   }
 
-  async create (name: string): Promise<ProjectId> {
-    const data = {
-      '@type': TYPE_PROJECT,
-      [PROP_NAME]: name
-    }
+  async operations () {
+    const resource = await this.resource()
+    return resource.operations
+  }
 
+  async create (data: object): Promise<ProjectId> {
     const resource = await this.resource()
     const operation = getOperation(resource, OP_PROJECTS_CREATE)
     const response = await operation.invoke(JSON.stringify(data))
@@ -182,6 +182,10 @@ class FixturesClient {
 
     async create () {
       throw new Error('Not implemented')
+    },
+
+    operations () {
+      return []
     },
 
     async createSource () {

--- a/ui/src/components/project/ProjectForm.vue
+++ b/ui/src/components/project/ProjectForm.vue
@@ -1,12 +1,11 @@
 <template>
-  <form class="modal-card" @submit.prevent="save(project)">
+  <form class="modal-card" @submit.prevent="save($refs.form.value)">
     <header class="modal-card-head">
-      <h3 class="modal-card-title">{{ title }}</h3>
+      <h3 class="modal-card-title">{{ operation.title }}</h3>
     </header>
     <section class="modal-card-body">
-      <b-field label="Name">
-        <b-input v-model="project.name" />
-      </b-field>
+      <alcaeus-form ref="form" :operation.prop="operation"
+                    no-legend no-submit-button no-reset-button no-clear-button></alcaeus-form>
     </section>
     <footer class="modal-card-foot">
       <button class="button" type="button" @click="$parent.close()">Cancel</button>
@@ -18,29 +17,13 @@
 <script lang="ts">
 import { Prop, Component, Vue } from 'vue-property-decorator'
 import { Project, Table, Rule, Source } from '../../types'
-import TableTag from '../TableTag.vue'
+import '@hydrofoil/alcaeus-forms/alcaeus-form'
+import { IOperation } from 'alcaeus/types/Resources'
 
 @Component
 export default class extends Vue {
-  @Prop({ default: emptyProject }) project: Project;
+  @Prop() project: Project;
   @Prop() save: (project: Project) => any;
-
-  get title () {
-    if (this.project.id) {
-      return 'Edit project'
-    } else {
-      return 'Create project'
-    }
-  }
-}
-
-function emptyProject (): Project {
-  return {
-    id: '',
-    name: '',
-    tables: [],
-    sources: [],
-    rules: []
-  }
+  @Prop() operation: IOperation
 }
 </script>

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -9,6 +9,9 @@ import 'buefy/dist/buefy.css'
 Vue.use(Buefy)
 
 Vue.config.productionTip = false
+Vue.config.ignoredElements = [
+  'alcaeus-form'
+]
 
 new Vue({
   router,

--- a/ui/src/store/modules/projects.ts
+++ b/ui/src/store/modules/projects.ts
@@ -1,10 +1,12 @@
 import { ActionTree, MutationTree, GetterTree } from 'vuex'
 import { ProjectsState, RootState } from '@/store/types'
 import { ProjectId, Project, RemoteData } from '@/types'
-import { client } from '../../api'
+import { client, OP_PROJECTS_CREATE } from '../../api'
+import { IOperation } from 'alcaeus/types/Resources'
 
 const initialState: ProjectsState = {
-  projects: { isLoading: true }
+  projects: { isLoading: true },
+  createOperation: null
 }
 
 const getters: GetterTree<ProjectsState, RootState> = {
@@ -30,7 +32,9 @@ const actions: ActionTree<ProjectsState, RootState> = {
   async loadAll ({ commit }) {
     try {
       const projects = await client.projects.list()
+      const operations = await client.projects.operations()
       commit('storeAll', projects)
+      commit('storeOperations', operations)
     } catch (error) {
       commit('loadingError', error)
     }
@@ -60,6 +64,10 @@ const actions: ActionTree<ProjectsState, RootState> = {
 }
 
 const mutations: MutationTree<ProjectsState> = {
+  storeOperations (state, operations: IOperation[]) {
+    state.createOperation = operations.find((op: IOperation) => op.supportedOperation.id === OP_PROJECTS_CREATE) || null
+  },
+
   storeAll (state, projects: Project[]) {
     const emptyData: Record<ProjectId, Project> = {}
     state.projects.data = projects.reduce((acc, project) => {

--- a/ui/src/store/types.ts
+++ b/ui/src/store/types.ts
@@ -1,7 +1,9 @@
 import { ProjectId, Project, RemoteData } from '../types'
+import { IOperation } from 'alcaeus/types/Resources'
 
 export interface RootState {}
 
 export interface ProjectsState {
   projects: RemoteData<Record<ProjectId, Project>>;
+  createOperation: IOperation | null
 }

--- a/ui/src/views/Projects.vue
+++ b/ui/src/views/Projects.vue
@@ -3,8 +3,8 @@
     <h2 class="title is-2">My projects</h2>
 
     <div class="actions">
-      <b-button type="is-primary" icon-left="plus" @click="addProject">
-        New project
+      <b-button type="is-primary" icon-left="plus" @click="addProject" v-if="createOperation">
+        {{ createOperation.title }}
       </b-button>
     </div>
 
@@ -53,6 +53,10 @@ export default class Projects extends Vue {
     return this.$store.getters['projects/list']
   }
 
+  get createOperation () {
+    return this.$store.state.projects.createOperation
+  }
+
   created () {
     this.$store.dispatch('projects/loadAll')
   }
@@ -62,8 +66,9 @@ export default class Projects extends Vue {
       parent: this,
       component: ProjectForm,
       props: {
+        operation: this.createOperation,
         save: (project: Project) => {
-          this.$store.dispatch('projects/create', project.name)
+          this.$store.dispatch('projects/create', project)
           modal.close()
         }
       },

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -1,5 +1,11 @@
 module.exports = {
-  transpileDependencies: ['alcaeus'],
+  transpileDependencies: [
+    'alcaeus',
+    '@lit-any/core',
+    '@lit-any/forms',
+    '@hydrofoil/alcaeus-forms',
+    'lit-element'
+  ],
   chainWebpack: config => {
     config.module
       .rule('nq')


### PR DESCRIPTION
Hi @martinmaillard 

I spearheaded the usage of hydra to generate the form and make the UI a little more dynamic. 

1. The `ProjectForm.vue` is almost universal form modal now. Pretty much can be used to run any hydra operation without any modifications already

2. Shall the operation to create a project be missing, the button will disappear. This is just one step from iterating all operations and rendering that many buttons for each operation.