### PR TITLE
fix: send base collection triples for /projects resource

### DIFF
--- a/api/hydra/projects/get.rq
+++ b/api/hydra/projects/get.rq
@@ -16,7 +16,7 @@ CONSTRUCT {
         a ?projectType .
 }
 WHERE {
-    ?project a dataCube:Project .
+    OPTIONAL { ?project a dataCube:Project . }
 
     OPTIONAL { ?project schema:name ?name . }
     OPTIONAL { ?project a ?projectType . }


### PR DESCRIPTION
@martinmaillard you mentioned that the collection of projects is incomplete when the database is initially empty.

Turns out that the SPARQL query would return empty graph in that case.

Adding an `OPTIONAL` block makes sure that the missing triples are now present

```
<projects>
    a hydra:Collection ;
    hydra:totalItems ?count .
```

Was there anything else?