### PR TITLE
feat: endpoint to fetch a sample of the source csv

### DIFF
--- a/api/hydra/api.ttl
+++ b/api/hydra/api.ttl
@@ -286,7 +286,29 @@ dataCube:Source
       hydra:title "Project" ;
       hydra:description "The project this source belongs to" ;
       hydra:writeable false
+    ] ,
+    [
+      hydra:property api:sample ;
+      hydra:title "Collection of sample row data" ;
+      hydra:writeable false
     ] .
+
+api:sample a hydra:Link ;
+  hydra:supportedOperation _:GetSourceSample .
+
+_:GetSourceSample
+  a hydra:SupportedOperation, hydra-box:View ;
+  hydra:method "GET" ;
+  hydra:title "Sample source rows" ;
+  code:implementedBy [
+    a hydra-box:middlewareChain ;
+    code:arguments (
+      [
+        a code:EcmaScript ;
+        code:link <file:lib/data-cube/project-source/sample#getSampleRows>
+      ]
+    )
+  ] .
 
 dataCube:project a hydra:Link .
 api:csvwMetadata a hydra:Link ;
@@ -632,4 +654,5 @@ api:Error
 </project/:projectId/table/:tableName> api:attributes </project/:projectId/table/:tableName/attributes> .
 </project/:projectId/table/:tableName> api:preview </project/:projectId/table/:tableName/preview> .
 </project/:projectId/source/:sourceId> a dataCube:Source .
+</project/:projectId/source/:sourceId> api:sample </project/:projectId/source-sample/:sourceId> .
 </project/:projectId/table/:tableName> api:csvwMetadata </project/:projectId/table/:tableName/csvw> .

--- a/api/hydra/project-source-collection/get.rq
+++ b/api/hydra/project-source-collection/get.rq
@@ -1,4 +1,5 @@
 PREFIX dataCube: <https://rdf-cube-curation.described.at/>
+PREFIX api: <https://rdf-cube-curation.described.at/api/>
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX hydra: <http://www.w3.org/ns/hydra/core#>
@@ -11,7 +12,8 @@ CONSTRUCT {
         hydra:totalItems ?count .
 
     ?source
-        schema:name ?name .
+        schema:name ?name ;
+        api:sample ?sample .
 }
 WHERE {
     BIND (<${this.locals.projectId}/sources> as ?collection)
@@ -21,6 +23,8 @@ WHERE {
         ?source a dataCube:Source ;
                 dataCube:project ?project ;
                 schema:name ?name .
+
+        BIND (iri(CONCAT(replace(str(?source), "/source/", "/source-sample/"))) as ?sample)
     }
 
     {

--- a/api/hydra/project-source/get.rq
+++ b/api/hydra/project-source/get.rq
@@ -1,10 +1,12 @@
+PREFIX api: <https://rdf-cube-curation.described.at/api/>
 PREFIX dataCube: <https://rdf-cube-curation.described.at/>
 PREFIX schema: <http://schema.org/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 CONSTRUCT
 {
-    ?source ?prop ?value .
+    ?source ?prop ?value ;
+            api:sample ?sample .
 }
 WHERE
 {
@@ -19,5 +21,6 @@ WHERE
 
     OPTIONAL {
         ?source ?prop ?value .
+        BIND (iri(CONCAT(replace(str(?source), "/source/", "/source-sample/"))) as ?sample)
     }
 }

--- a/api/lib/data-cube/project-source/index.ts
+++ b/api/lib/data-cube/project-source/index.ts
@@ -1,11 +1,22 @@
+import express from 'express'
 import { getProjectId } from '../project'
 
 function getSourceId (projectId: string, sourceName: string) {
   return `${projectId}/source/${sourceName}`
 }
 
+export function getSourceIdFromRoute (req: express.Request) {
+  const projectId = getProjectId(req.params.projectId)
+  return {
+    projectId,
+    sourceId: getSourceId(projectId, req.params.sourceId),
+  }
+}
+
 export function initExisting (req, res, next) {
-  res.locals.projectId = getProjectId(req.params.projectId)
-  res.locals.sourceId = getSourceId(res.locals.projectId, req.params.sourceId)
+  const { projectId, sourceId } = getSourceIdFromRoute(req)
+
+  res.locals.projectId = projectId
+  res.locals.sourceId = sourceId
   next()
 }

--- a/api/lib/data-cube/project-source/sample.ts
+++ b/api/lib/data-cube/project-source/sample.ts
@@ -1,0 +1,49 @@
+import express from 'express'
+import $rdf from 'rdf-ext'
+import cf from 'clownface'
+import { loadSampleRows } from '../../services/sourceSamples'
+import { asyncRoute } from '../../express'
+import { getSourceIdFromRoute } from './index'
+import { NotFoundError } from '../../error'
+import { api, hydra, rdf } from '../../namespaces'
+
+function buildCollectionGraph (collectionId: string, currentPageUrl: string, nextPageUrl: string, rows: string[][]) {
+  const dataset = $rdf.dataset()
+  const collection = cf(dataset).node($rdf.namedNode(collectionId))
+
+  collection.addOut(rdf.type, hydra.Collection)
+
+  rows.forEach(row => {
+    collection.addOut(hydra.member, member => {
+      member.addList(api.cells, row)
+    })
+  })
+
+  collection.addOut(hydra.view, $rdf.namedNode(currentPageUrl), view => {
+    view.addOut(rdf.type, hydra.PartialCollectionView)
+    view.addOut(hydra.next, $rdf.namedNode(nextPageUrl))
+  })
+
+  return dataset
+}
+
+export const getSampleRows = asyncRoute(async (req: express.DataCubeRequest, res: express.DataCubeResponse, next: express.NextFunction) => {
+  const { sourceId } = getSourceIdFromRoute(req)
+  const collectionId = sourceId.replace('/source/', '/source-sample/')
+  const limit = Number.parseInt(req.query.limit) || 5
+  const offset = Number.parseInt(req.query.offset) || 0
+
+  const sampleData = await loadSampleRows(sourceId.replace(process.env.BASE_URI, ''), limit, offset)
+
+  // TODO: remove once clownface #17 is fixed
+  const sampleDataLiterals = sampleData.map(cells => cells.map($rdf.literal)) as any
+
+  if (sampleData) {
+    const currentPageUrl = `${collectionId}?limit=${limit}&offset=${offset}`
+    const nextPageUrl = `${collectionId}?limit=${limit}&offset=${offset + 5}`
+    res.setLink(currentPageUrl, 'canonical')
+    res.graph(buildCollectionGraph(collectionId, currentPageUrl, nextPageUrl, sampleDataLiterals).toStream())
+  } else {
+    next(new NotFoundError())
+  }
+})

--- a/api/lib/services/sourceSamples.ts
+++ b/api/lib/services/sourceSamples.ts
@@ -1,7 +1,43 @@
 import md5 from 'md5'
+import parse from 'csv-parse'
 import storage from '../storage'
 
 export function loadSourceSample (sourceId: string) {
   const pathName = md5(sourceId)
   return storage.loadFile(pathName)
+}
+
+export async function loadSampleRows (sourceId: string, limit: number, offset: number) {
+  let result: string[][] = []
+  const fileStream = await loadSourceSample(sourceId)
+
+  if (fileStream == null) {
+    return null
+  }
+
+  return new Promise<string[][]>((resolve) => {
+    const parser = parse({
+      to: offset + 1 + limit,
+      from: offset + 2,
+      delimiter: ';',
+    })
+
+    parser.on('readable', () => {
+      let record: string[]
+      while (true) {
+        record = parser.read()
+        if (record) {
+          result.push(record)
+        } else {
+          break
+        }
+      }
+    })
+
+    parser.on('end', () => {
+      resolve(result)
+    })
+
+    fileStream.pipe(parser)
+  })
 }

--- a/api/lib/storage/local.ts
+++ b/api/lib/storage/local.ts
@@ -11,7 +11,7 @@ export async function deleteFile (path: string) {
 }
 
 export function loadFile (path: string) {
-  if (!existsSync(path)) {
+  if (!existsSync(`${process.env.STORAGE_FILESYSTEM_PATH}/${path}`)) {
     return null
   }
 


### PR DESCRIPTION
This PR adds an `api:sample` link to instance of `dataCube:Sources`. Both on the individual resource as well as inlined in the project representation.

Each member is blank node representing a row with a an ordered list of strings. Something like below pseudo-interface

```ts
interface SampleRowsCollection {
  member: {
    'api:cells': string[]
  }[]
}
```

The sample itself is a `hydra:Collection` split in 5-item pages. To go through the pages:

```js
let source
const samples = source['api:sample'] as Collection
const pager = samples.views[0] as IPartialCollectionView
const nextPage = await pager.next.load() as Collection
```

Note that each call to `next.load()` returns a collection with `members` being a portion of the entire set.