### PR TITLE
CI: Use wait-on to wait on stuff

### DIFF
--- a/.ci/analyse.yml
+++ b/.ci/analyse.yml
@@ -29,14 +29,15 @@ run:
     - -euxc
     - |
       apt-get update; apt-get install -y default-jre
+      npm install -g wait-on
       curl -s http://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz | tar -xz
       ( cd ./apache-jena-fuseki-$FUSEKI_VERSION; ./fuseki-server > /dev/null ) &
-      until $(curl --output /dev/null --silent --head --fail http://localhost:3030); do sleep 5; done
+      wait-on --timeout 30000 http://localhost:3030
       curl 'http://localhost:3030/$/datasets' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'dbName=data-cube-e2e&dbType=mem'
       curl 'http://localhost:3030/$/datasets' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'dbName=data-cube-read&dbType=mem'
       cd repo
       npm ci --unsafe-perm
       cp ./api/.env.local ./api/.env
       npm run start:api > /dev/null &
-      until $(curl --output /dev/null --silent --head --fail http://localhost:5678); do sleep 5; done
+      wait-on --timeout 20000 http://localhost:5678
       npm run test:analyse

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -29,14 +29,15 @@ run:
     - -euxc
     - |
       apt-get update; apt-get install -y default-jre
+      npm install -g wait-on
       curl -s http://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz | tar -xz
       ( cd ./apache-jena-fuseki-$FUSEKI_VERSION; ./fuseki-server > /dev/null ) &
-      until $(curl --output /dev/null --silent --head --fail http://localhost:3030); do sleep 5; done
+      wait-on --timeout 30000 http://localhost:3030
       curl 'http://localhost:3030/$/datasets' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'dbName=data-cube-e2e&dbType=mem'
       curl 'http://localhost:3030/$/datasets' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'dbName=data-cube-read&dbType=mem'
       cd repo
       npm ci --unsafe-perm
       cp ./api/.env.local ./api/.env
       npm run start:api > /dev/null &
-      until $(curl --output /dev/null --silent --head --fail http://localhost:5678); do sleep 5; done
+      wait-on --timeout 20000 http://localhost:5678
       npm run test


### PR DESCRIPTION
Should prevent the job from running forever if the API doesn't start.