### PR TITLE
fix: return 404 when a project does not have a fact table

### DIFF
--- a/api/lib/data-cube/project/index.ts
+++ b/api/lib/data-cube/project/index.ts
@@ -6,6 +6,7 @@ import { buildVariables } from '../../buildVariables'
 import { expand } from '@zazuko/rdf-vocabularies'
 import { getExistingProject } from './get'
 import { getFactTableId } from '../../read-graphs/table'
+import { NotFoundError } from '../../error'
 
 export { getTables } from './getTables'
 
@@ -62,7 +63,14 @@ export async function createOrUpdate (req: express.DataCubeRequest, res: express
 
 export async function getFactTable (req: express.DataCubeRequest, res: express.DataCubeResponse, next: express.NextFunction) {
   getFactTableId(getProjectId(req.params.projectId))
-    .then(value => res.redirect(value, 303))
+    .then(value => {
+      if (!value) {
+        next(new NotFoundError())
+        return
+      }
+
+      return res.redirect(value, 303)
+    })
     .catch(next)
 }
 

--- a/api/lib/read-graphs/table.ts
+++ b/api/lib/read-graphs/table.ts
@@ -79,7 +79,13 @@ export function getFactTableId (projectId: string) {
       dataCube,
     })
     .execute(getClient())
-    .then(bindings => bindings[0].factTable.value)
+    .then(bindings => {
+      if (bindings.length === 0) {
+        return null
+      }
+
+      return bindings[0].factTable.value
+    })
 }
 
 export function existsInTableSource (tableId: string, columnId: string): Promise<boolean> {

--- a/api/test/FactTable/GetWhenItDoesNotExist.hydra
+++ b/api/test/FactTable/GetWhenItDoesNotExist.hydra
@@ -1,0 +1,33 @@
+PREFIX api: <https://rdf-cube-curation.described.at/api/>
+PREFIX dataCube: <https://rdf-cube-curation.described.at/>
+PREFIX schema: <http://schema.org/>
+
+With Class api:ProjectPlaceholder {
+    Expect Property api:project {
+        Expect Operation schema:CreateAction
+    }
+}
+
+With Class dataCube:Project {
+    With Operation api:DeleteProject {
+        Invoke {
+            Expect Status 204
+        }
+    }
+}
+
+With Operation schema:CreateAction {
+    Invoke {
+        Content-Type "text/turtle"
+
+        ```
+        @prefix schema: <http://schema.org/> .
+
+        <> schema:name "Fact table project" .
+        ```
+    } => {
+        Expect Link dataCube:factTable {
+            Expect Status 404
+        }
+    }
+}

--- a/api/test/run.ts
+++ b/api/test/run.ts
@@ -14,6 +14,7 @@ const scenarios = Object.entries({
   CreateDataCubeProject: '',
   'FactTable/CreateWithPut': 'project/fact-table-test',
   'FactTable/CreateWithPost': 'project/fact-table-post-test',
+  'FactTable/GetWhenItDoesNotExist': 'project/fact-table-404',
   'DimensionTable/Create': 'project/dimension-table-test',
   CreateFactTableAttribute: 'project/add-attribute-test',
   CreateFactTableAttributeWithDataType: 'project/attribute-datatype-test',


### PR DESCRIPTION
I cannot reproduce the other failed request where the API complains about fact table already being created