### PR TITLE
fix: add schema:ViewAction type to sample operation

### DIFF
--- a/api/hydra/api.ttl
+++ b/api/hydra/api.ttl
@@ -298,7 +298,7 @@ api:sample a hydra:Link ;
   hydra:supportedOperation _:GetSourceSample .
 
 _:GetSourceSample
-  a hydra:SupportedOperation, hydra-box:View ;
+  a hydra:SupportedOperation, hydra-box:View, schema:ViewAction ;
   hydra:method "GET" ;
   hydra:title "Sample source rows" ;
   code:implementedBy [


### PR DESCRIPTION
Without an ID or a type, I think I have no way to find this operation.