### PR TITLE
build: disable prefetch plugin

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "raw-loader": "3.1.0",
     "ts-jest": "^23.0.0",
     "typescript": "^3.4.3",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "^2.6.10",
+    "webpack": "^4.41.1"
   }
 }

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack')
+
 module.exports = {
   publicPath: process.env.NODE_ENV === 'production' ? '/app' : '/',
   transpileDependencies: ['alcaeus'],
@@ -9,8 +11,26 @@ module.exports = {
       .loader('raw-loader')
       .end()
 
-    // Disable auto-prefetching because it was prefetching all the ontologies
-    // of the rdf-vocabularies dependency.
-    config.plugins.delete('prefetch')
+    config.plugin('prefetch').tap(options => {
+      options[0].fileBlacklist = options[0].fileBlacklist || []
+      options[0].fileBlacklist.push(/vocab-\w+\.js$/)
+      return options
+    })
+  },
+  configureWebpack: {
+    plugins: [
+      new webpack.NamedChunksPlugin((chunk) => {
+        const vocabModule = [...chunk._modules].find(m => /rdf-vocabularies\/ontologies$/.test(m.context))
+
+        if (vocabModule) {
+          const matchVocabName = vocabModule.id.match(/(\w+)\.nq$/)
+          if (matchVocabName) {
+            return 'vocab-' + matchVocabName[1]
+          }
+        }
+
+        return chunk.name
+      })
+    ]
   }
 }


### PR DESCRIPTION
Prevents ontology graphs from `@zazuko/rdf-vocabularies` from being prefetched