### PR TITLE
fix: set base URI on the parser which reads the API docs graph

### DIFF
--- a/api/hydra/api.ttl
+++ b/api/hydra/api.ttl
@@ -1,6 +1,3 @@
-# TODO: get rid of base and provide from env variables
-@base <http://localhost:5678/> .
-
 @prefix api: <https://rdf-cube-curation.described.at/api/> .
 @prefix dataCube: <https://rdf-cube-curation.described.at/> .
 @prefix hydra: <http://www.w3.org/ns/hydra/core#> .

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,15 +1,14 @@
 import cors from 'cors'
 import path from 'path'
-import hydraBox from 'hydra-box'
 import url from 'url'
 import express from 'express'
-import replace from 'replace-in-file'
 import dotenv from 'dotenv'
 import dotenvExpand from 'dotenv-expand'
 import debug from 'debug'
 import { NotFoundError } from './lib/error'
 import { httpProblemMiddleware } from './lib/error/middleware'
 import frontend, { rootRedirect } from './frontend'
+import hydraMiddleware from './lib/hydra-box'
 
 dotenvExpand(dotenv.config())
 import('./lib/handlers')
@@ -33,33 +32,6 @@ function logger (req: express.Request, res, next) {
   next()
 }
 
-async function hydraMiddleware () {
-  let authentication
-  if (process.env.SPARQL_ENDPOINT_USERNAME && process.env.SPARQL_ENDPOINT_PASSWORD) {
-    authentication = {
-      user: process.env.SPARQL_ENDPOINT_USERNAME,
-      password: process.env.SPARQL_ENDPOINT_PASSWORD,
-    }
-  }
-
-  const options: Record<string, unknown> = {
-    debug: true,
-    sparqlEndpointUrl: process.env.READ_MODEL_SPARQL_ENDPOINT,
-    sparqlEndpointUpdateUrl: process.env.SPARQL_UPDATE_ENDPOINT,
-    contextHeader: '/context/',
-    authentication,
-  }
-
-  const apiDocsPath = path.join(__dirname, 'hydra/api.ttl')
-  await replace({
-    files: apiDocsPath,
-    from: /@base <.+>/,
-    to: `@base <${process.env.BASE_URI}>`,
-  })
-
-  return hydraBox.fromUrl('/api', 'file://' + apiDocsPath, options)
-}
-
 Promise.resolve().then(async () => {
   const baseUrl = `${process.env.BASE_URI}`
 
@@ -74,7 +46,7 @@ Promise.resolve().then(async () => {
   app.use(cors({
     exposedHeaders: ['link', 'location'],
   }))
-  app.use(await hydraMiddleware())
+  app.use(await hydraMiddleware(path.join(__dirname, 'hydra/api.ttl')))
   app.use(function (req, res, next) {
     next(new NotFoundError())
   })

--- a/api/lib/hydra-box.ts
+++ b/api/lib/hydra-box.ts
@@ -1,0 +1,30 @@
+import hydraBox from 'hydra-box'
+import Parser from '@rdfjs/parser-n3'
+import { dataset } from 'rdf-ext'
+import { createReadStream } from 'fs'
+
+export default async function (apiPath: string) {
+  const parser = new Parser({
+    baseIRI: process.env.BASE_URI,
+  })
+
+  let authentication
+  if (process.env.SPARQL_ENDPOINT_USERNAME && process.env.SPARQL_ENDPOINT_PASSWORD) {
+    authentication = {
+      user: process.env.SPARQL_ENDPOINT_USERNAME,
+      password: process.env.SPARQL_ENDPOINT_PASSWORD,
+    }
+  }
+
+  const options: Record<string, unknown> = {
+    debug: true,
+    sparqlEndpointUrl: process.env.READ_MODEL_SPARQL_ENDPOINT,
+    sparqlEndpointUpdateUrl: process.env.SPARQL_UPDATE_ENDPOINT,
+    contextHeader: '/context/',
+    authentication,
+  }
+
+  const apiDocsFile = createReadStream(apiPath)
+
+  return hydraBox('/api', await dataset().import(parser.import(apiDocsFile)), options)
+}


### PR DESCRIPTION
By parsing the API graph ourselves we can set the BASE URI from the environment variable and not have it hardcoded any more.

This way we will also be able to split the `api.ttl` file into smaller chunks and load them separately, in parallel.