### PR TITLE
build: chunk name plugin was skipped in production mode. use vue plugin

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,6 @@
     "raw-loader": "3.1.0",
     "ts-jest": "^23.0.0",
     "typescript": "^3.4.3",
-    "vue-template-compiler": "^2.6.10",
-    "webpack": "^4.41.1"
+    "vue-template-compiler": "^2.6.10"
   }
 }


### PR DESCRIPTION
OMG, hopefully this is the last time I touch this. Apparently vue creates another chunk namer plugin which supersedes the one I added before.

I change the setup so that the production build is adjusted and development build is unchanged.

