### PR TITLE
build(console): use debug library for logging

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1416,6 +1416,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -5022,7 +5028,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -10534,8 +10539,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "alcaeus": "^0.10.3",
     "buefy": "^0.8.6",
     "core-js": "^3.3.6",
+    "debug": "^4.1.1",
     "vue": "^2.6.10",
     "vue-class-component": "^7.0.2",
     "vue-property-decorator": "^8.3.0",
@@ -21,6 +22,7 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.5",
     "@types/jest": "^23.1.4",
     "@vue/cli-plugin-babel": "^4.0.5",
     "@vue/cli-plugin-e2e-cypress": "^4.0.5",

--- a/ui/src/api/common.ts
+++ b/ui/src/api/common.ts
@@ -1,5 +1,8 @@
 import { HydraResource, IOperation } from 'alcaeus/types/Resources'
+import debug from 'debug'
 import { ResourceId } from '@/types'
+
+const log = debug('api')
 
 export type Constructor<T = {}> = new (...args: any[]) => HydraResource;
 
@@ -9,7 +12,7 @@ export function findOperation (resource: HydraResource, idOrType: ResourceId): I
   })
 
   if (matches.length > 1) {
-    console.warn(`More than one match for operation ${idOrType} on ${resource.id}`)
+    log(`More than one match for operation ${idOrType} on ${resource.id}`)
   }
 
   return matches[0] || null


### PR DESCRIPTION
We failed to notice that `console.log` break typescript compilation. I added `debug` instead