### PR TITLE
feat(ui): auto-complete identifier template columns

### DIFF
--- a/ui/src/components/IdentifierTemplateInput.vue
+++ b/ui/src/components/IdentifierTemplateInput.vue
@@ -7,7 +7,8 @@
       @select="onSelect"
       :data="propositions"
       :custom-formatter="formatProposition"
-      placeholder="my-table/{column_id}"
+      placeholder="e.g. my-table/{column_id}"
+      :disabled="!source"
       required>
   </b-autocomplete>
 </template>

--- a/ui/src/components/IdentifierTemplateInput.vue
+++ b/ui/src/components/IdentifierTemplateInput.vue
@@ -1,0 +1,82 @@
+<template>
+  <b-autocomplete
+      ref="autocomplete"
+      :value="value"
+      @input="onUpdate"
+      @typing="onTyping"
+      @select="onSelect"
+      :data="propositions"
+      :custom-formatter="formatProposition"
+      placeholder="my-table/{column_id}"
+      required>
+  </b-autocomplete>
+</template>
+
+<script lang="ts">
+import { Prop, Component, Vue, Watch } from 'vue-property-decorator'
+import { Source } from '@/types'
+
+@Component
+export default class extends Vue {
+  @Prop() value: string
+  @Prop() tableName: string
+  @Prop() source: Source
+  wasModified = false;
+
+  onUpdate (newValue: string) {
+    this.$emit('input', newValue)
+  }
+
+  onTyping () {
+    this.wasModified = true
+  }
+
+  @Watch('tableName')
+  prefill () {
+    if (this.wasModified) return
+
+    if (!this.tableName) return
+
+    const prefillValue = `${this.tableName.toLowerCase()}/{_}`
+    this.$emit('input', prefillValue)
+  }
+
+  getInputElement () {
+    const autocomplete = this.$refs.autocomplete as Vue
+    return autocomplete ? autocomplete.$el.querySelector('input') : null
+  }
+
+  getPosition (): number {
+    const inputElement = this.getInputElement()
+
+    return inputElement ? (inputElement.selectionStart || 0) : 0
+  }
+
+  get propositions () {
+    const value = this.value
+    const position = this.getPosition()
+
+    const prevChar = this.value[position - 1]
+
+    if (prevChar === '{') {
+      return this.source.columns.map((c) => c.name)
+    } else {
+      return []
+    }
+  }
+
+  formatProposition (proposition: string) {
+    const position = this.getPosition()
+    const nextChar = this.value[position]
+    const insert = nextChar === '}' ? proposition : proposition + '}'
+    const newValue = this.value.substring(0, position) + insert + this.value.substring(position)
+
+    return newValue
+  }
+
+  onSelect () {
+    const inputElement = this.getInputElement()
+    inputElement && inputElement.focus()
+  }
+}
+</script>

--- a/ui/src/components/project/TableAdvancedForm.vue
+++ b/ui/src/components/project/TableAdvancedForm.vue
@@ -33,7 +33,7 @@
       </div>
 
       <b-field label="Identifier attribute template" v-if="table.type != 'fact'">
-        <b-input type="text" v-model="table.identifierTemplate" placeholder="http://example.org/{column_id}" required />
+        <IdentifierTemplateInput v-model="table.identifierTemplate" :tableName="table.name" :source="source" />
       </b-field>
 
       <b-field label="Properties">
@@ -94,10 +94,12 @@
 <script lang="ts">
 import { Prop, Component, Vue } from 'vue-property-decorator'
 import { TableType, ResourceId, Project, Source, ValueAttribute, TableFormData, ValueAttributeFormData } from '@/types'
+import IdentifierTemplateInput from '../IdentifierTemplateInput.vue'
 import LanguageInput from '../LanguageInput.vue'
 
 @Component({
   components: {
+    IdentifierTemplateInput,
     LanguageInput
   }
 })

--- a/ui/src/components/project/TableForm.vue
+++ b/ui/src/components/project/TableForm.vue
@@ -41,7 +41,7 @@
       </b-field>
 
       <b-field label="Identifier attribute template" v-if="table.type != 'fact'">
-        <b-input type="text" v-model="table.identifierTemplate" placeholder="http://example.org/{column_id}" required />
+        <IdentifierTemplateInput v-model="table.identifierTemplate" :tableName="table.name" :source="source" />
       </b-field>
     </section>
     <footer class="modal-card-foot">
@@ -54,8 +54,13 @@
 <script lang="ts">
 import { Prop, Component, Vue } from 'vue-property-decorator'
 import { TableType, ResourceId, Project, Source, TableFormData } from '@/types'
+import IdentifierTemplateInput from '../IdentifierTemplateInput.vue'
 
-@Component
+@Component({
+  components: {
+    IdentifierTemplateInput
+  }
+})
 export default class TableForm extends Vue {
   @Prop({ default: emptyTable }) readonly table: TableFormData;
   @Prop() readonly project: Project;
@@ -82,6 +87,12 @@ export default class TableForm extends Vue {
     } else {
       return 'Create table'
     }
+  }
+
+  get source () {
+    if (!this.table.sourceId) return null
+
+    return this.sources.find((source) => source.id === this.table.sourceId)
   }
 }
 


### PR DESCRIPTION
This is a first attempt at improving the "identifier template" input with:
- Clearer placeholder
- Auto-fill once table name is provided
- Auto-complete on column names between "{" and "}"

It is far from perfect. A better solution will probably have to include an actual parser to improve the auto-complete and add column validation.

Fixes #164