### PR TITLE
fix(ui): regression in reference attr. form

### DIFF
--- a/ui/src/components/PropertyField.vue
+++ b/ui/src/components/PropertyField.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
 import { Project } from '@/types'
 import { expand, expandWithBase, shrink } from '@/rdf-vocabularies'
 
@@ -37,6 +37,12 @@ export default class extends Vue {
 
   get expandedValue () {
     return expandWithBase(this.value, this.project.baseUri)
+  }
+
+  // Set `shortProperty` when value is changed from the outside
+  @Watch('value')
+  setShortProperty (value: string) {
+    this.shortProperty = shrink(value)
   }
 }
 </script>

--- a/ui/src/components/project/ReferenceAttributeForm.vue
+++ b/ui/src/components/project/ReferenceAttributeForm.vue
@@ -22,7 +22,7 @@
       </p>
       <PropertyField :project="project" v-model="attribute.predicateId" required />
 
-      <div v-if="referencedTable">
+      <div v-if="referencedTable" v-show="attribute.columnMapping.length > 0">
         <p>
           The identifier <code>{{ referencedTable.identifierTemplate }}</code> shall use
           the columns


### PR DESCRIPTION
1. The property field was not auto-populated when selecting the table because of the new property field behavior.
2. We should also hide the "columns mapping" section when there are no columns in the identifier.