### PR TITLE
fix: replace rdf:predicate with property template completely

### DIFF
--- a/api/lib/data-cube/table/attributes/addReferenceAttribute.ts
+++ b/api/lib/data-cube/table/attributes/addReferenceAttribute.ts
@@ -43,8 +43,7 @@ export const addReferenceAttributeHandler = asyncMiddleware(async (req: Request,
     throw new NotFoundError()
   }
 
-  const { predicate, propertyTemplate, referencedTableId, columnMappingNodes } = buildVariables(req, {
-    predicate: expand('rdf:predicate'),
+  const { propertyTemplate, referencedTableId, columnMappingNodes } = buildVariables(req, {
     propertyTemplate: expand('dataCube:propertyTemplate'),
     referencedTableId: expand('dataCube:referencedTable'),
     columnMappingNodes: expand('dataCube:columnMapping'),
@@ -60,7 +59,7 @@ export const addReferenceAttributeHandler = asyncMiddleware(async (req: Request,
   }
 
   const attribute = await aggregate.factory(addReferenceAttribute)({
-    propertyTemplate: (propertyTemplate && propertyTemplate.value) || (predicate && predicate.value),
+    propertyTemplate: (propertyTemplate && propertyTemplate.value),
     referencedTableId: referencedTableId && referencedTableId.value,
     columnMappings,
   })

--- a/api/lib/data-cube/table/attributes/addValueAttribute.ts
+++ b/api/lib/data-cube/table/attributes/addValueAttribute.ts
@@ -16,7 +16,6 @@ export const addValueAttributeHandler = asyncMiddleware(async (req: express.Requ
   }
 
   const variables = buildVariables(req, {
-    predicate: expand('rdf:predicate'),
     propertyTemplate: expand('dataCube:propertyTemplate'),
     datatype: expand('dataCube:datatype'),
     language: expand('dataCube:language'),
@@ -32,7 +31,7 @@ export const addValueAttributeHandler = asyncMiddleware(async (req: express.Requ
   }
 
   const attribute = await aggregate.factory(addValueAttribute)({
-    propertyTemplate: (variables.propertyTemplate && variables.propertyTemplate.value) || (variables.predicate && variables.predicate.value),
+    propertyTemplate: (variables.propertyTemplate && variables.propertyTemplate.value),
     datatype: variables.datatype && variables.datatype.value,
     columnId: variables.columnId && variables.columnId.value,
     language: variables.language && variables.language.value,

--- a/api/lib/read-graphs/attribute.ts
+++ b/api/lib/read-graphs/attribute.ts
@@ -1,12 +1,10 @@
 import { CoreEvents, handle } from '@tpluscode/fun-ddr'
 import $rdf from 'rdf-ext'
-import cf from 'clownface'
 import { construct, deleteInsert, insertData } from '../sparql'
 import { api, dataCube, hydra, rdf, schema } from '../namespaces'
 import { getClient } from './sparqlClient'
 import { AttributeEvents } from '../domain/attribute/events'
 import './attribute/eventHandlers'
-import { DatasetCore } from 'rdf-js'
 
 handle<AttributeEvents, 'ValueAttributeAdded'>('ValueAttributeAdded', function addAttributeToReadModel (ev) {
   const builder = insertData(`
@@ -46,16 +44,6 @@ handle<CoreEvents, 'AggregateDeleted'>('AggregateDeleted', async function delete
       .execute(getClient())
   }
 })
-
-function mapPredicateToPropertyTemplate (dataset: DatasetCore) {
-  cf({ dataset })
-    .has(rdf.type, dataCube.Attribute)
-    .has(rdf.predicate)
-    .forEach((node) => {
-      node.addOut(dataCube.propertyTemplate, node.out(rdf.predicate))
-      node.deleteOut(rdf.predicate)
-    })
-}
 
 export async function getTableAttributes (tableId: string) {
   const collection = $rdf.dataset()
@@ -126,8 +114,6 @@ export async function getTableAttributes (tableId: string) {
     .prefixes({ dataCube, schema })
     .execute(getClient()))
 
-  mapPredicateToPropertyTemplate(collection)
-
   return collection
 }
 
@@ -156,8 +142,6 @@ export async function getSingleAttribute (attributeId: string) {
   if (attribute.length === 0) {
     return null
   }
-
-  mapPredicateToPropertyTemplate(attribute)
 
   return attribute
 }

--- a/api/lib/read-model/Table/Attribute.ts
+++ b/api/lib/read-model/Table/Attribute.ts
@@ -1,15 +1,12 @@
 import { Constructor, namespace, property, RdfResource, RdfResourceImpl } from '@tpluscode/rdfine'
 import * as Table from './index'
-import { dataCube, rdf } from '../../namespaces'
+import { dataCube } from '../../namespaces'
 import './ColumnMapping'
 import { BaseTable } from './Table'
 
 function AttributeMixin<TBase extends Constructor> (Base: TBase) {
   @namespace(dataCube)
   class Attribute extends Base implements Table.Attribute {
-    @property.literal({ path: rdf.predicate })
-    public predicate: string | null
-
     @property.literal()
     public propertyTemplate: string
   }

--- a/api/lib/read-model/Table/index.ts
+++ b/api/lib/read-model/Table/index.ts
@@ -16,7 +16,6 @@ export interface Column extends RdfResource {
 }
 
 export interface Attribute extends RdfResource {
-  readonly predicate: string | null;
   readonly propertyTemplate: string;
 }
 

--- a/api/lib/services/csvwBuilder.spec-graphs.ts
+++ b/api/lib/services/csvwBuilder.spec-graphs.ts
@@ -37,7 +37,7 @@ const mappedColumn = `${tableAndSource}
       a dataCube:Attribute, dataCube:ValueAttribute ;
       dataCube:column <http://example.com/column/station_name> ;
       dataCube:table <${ids.tableId}> ;
-      rdf:predicate <http://schema.org/name> .
+      dataCube:propertyTemplate <http://schema.org/name> .
 `
 
 const multipleMappedColumns = `${mappedColumn}
@@ -46,7 +46,7 @@ const multipleMappedColumns = `${mappedColumn}
       a dataCube:Attribute, dataCube:ValueAttribute ;
       dataCube:column <http://example.com/column/station_name> ;
       dataCube:table <${ids.tableId}> ;
-      rdf:predicate <http://schema.org/name> ;
+      dataCube:propertyTemplate <http://schema.org/name> ;
       dataCube:language "fr" .
 `
 
@@ -90,7 +90,7 @@ BASE <http://reference-attribute.test/fact-table>
     a dataCube:Attribute, dataCube:ReferenceAttribute ;
     dataCube:table <fact-table> ;
     dataCube:referencedTable <dim-table> ;
-    rdf:predicate schema:identifier ;
+    dataCube:propertyTemplate schema:identifier ;
     dataCube:columnMapping [
         dataCube:sourceColumn <fact-source/name-column> ;
         dataCube:referencedColumn <dim-source/name-column> ;

--- a/api/lib/services/csvwBuilder.spec.ts
+++ b/api/lib/services/csvwBuilder.spec.ts
@@ -155,38 +155,5 @@ describe('csvwBuilder', () => {
       // then
       expect(csvwDataset.tableSchema.columns[0].propertyUrl).toEqual('http://example.com/tst-project/property/{foo}/{bar}')
     })
-
-    it('uses concrete rdf:property if template is missing', async () => {
-      // given
-      const column: Partial<Column> = {
-        id: namedNode('http://reference-attribute.test/column'),
-        name: 'column',
-      }
-      const attribute: RecursivePartial<ValueAttribute> = {
-        id: namedNode('http://reference-attribute.test/attribute'),
-        column,
-        datatype: { id: xsd.string },
-        propertyTemplate: '',
-        predicate: 'http://example.com/prop',
-      }
-      const table: RecursivePartial<DimensionTable> = {
-        id: namedNode('http://reference-attribute.test/fact-table'),
-        identifierTemplate: 'table/{foo}/{bar}',
-        columns: [column],
-        attributes: [attribute],
-        types: [
-          dataCube.DimensionTable,
-        ],
-        project: {
-          baseUri: 'http://example.com/tst-project/',
-        },
-      }
-
-      // when
-      const csvwDataset = buildCsvw(table as any)
-
-      // then
-      expect(csvwDataset.tableSchema.columns[0].propertyUrl).toEqual('http://example.com/prop')
-    })
   })
 })

--- a/api/lib/services/csvwBuilder.ts
+++ b/api/lib/services/csvwBuilder.ts
@@ -34,7 +34,7 @@ function createCsvwColumn (csvwGraph: Csvw.Mapping, table: Table.Table, attribut
   }
 
   if (csvwColumn) {
-    const propertyTemplate = attribute.propertyTemplate || attribute.predicate
+    const propertyTemplate = attribute.propertyTemplate
     const parsed = parser.parse(propertyTemplate)
     csvwColumn.propertyUrl = getAbsoluteUrl(table.project, parsed)
     return csvwColumn

--- a/api/lib/storage/repository/attributes.ts
+++ b/api/lib/storage/repository/attributes.ts
@@ -3,7 +3,6 @@ import { Attribute } from '../../domain/attribute'
 import { expand } from '@zazuko/rdf-vocabularies'
 
 const context = {
-  predicate: { '@id': expand('rdf:predicate'), '@type': '@id' },
   datatype: { '@id': expand('rdf:type'), '@type': '@id' },
   table: { '@id': 'table', '@type': '@id' },
   column: { '@id': 'column', '@type': '@id' },

--- a/api/test/Attribute/DeleteValueAttribute.hydra
+++ b/api/test/Attribute/DeleteValueAttribute.hydra
@@ -66,7 +66,7 @@ With Class dataCube:Table {
                 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
                 <> dataCube:column <project/delete-value-attribute/source/single-column-csv/station-id> ;
-                   rdf:predicate <http://schema.org/identifier> ;
+                   dataCube:propertyTemplate <http://schema.org/identifier> ;
                    a dataCube:ValueAttribute .
                 ```
             } => {

--- a/api/test/DimensionTable/CsvwMapping/SetsReferencedValueUrl.hydra
+++ b/api/test/DimensionTable/CsvwMapping/SetsReferencedValueUrl.hydra
@@ -100,7 +100,7 @@ With Class dataCube:FactTable {
                 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
                 <> dataCube:referencedTable <project/reference-attribute-csvw-value-url/table/Stations> ;
-                   rdf:predicate <http://example.org/station> ;
+                   dataCube:propertyTemplate <http://example.org/station> ;
                    a dataCube:ReferenceAttribute ;
                    dataCube:columnMapping [
                        # TODO: substitue from env variables


### PR DESCRIPTION
Query to migrate the `READ_MODEL` store. Already fired on the staging environment

```sparql
PREFIX dataCube: <https://rdf-cube-curation.described.at/> 

DELETE
{
  ?attr rdf:predicate ?predicate .
}
INSERT
{
  ?attr dataCube:propertyTemplate ?pStr .
}
WHERE
{
  ?attr a dataCube:Attribute ;
    rdf:predicate ?predicate .

  BIND (str(?predicate) as ?pStr)
}
```