### PR TITLE
feat(ui): add project settings tab

### DIFF
--- a/api/hydra/projects.ttl
+++ b/api/hydra/projects.ttl
@@ -104,7 +104,7 @@ api:sources
 api:DeleteProject
   a                  hydra:SupportedOperation, hydra-box:View ;
   hydra:method       "DELETE" ;
-  hydra:title        "Deletes a project" ;
+  hydra:title        "Delete project" ;
   code:implementedBy [ a              hydra-box:middlewareChain ;
                        code:arguments ( [ a         code:EcmaScript ;
                                           code:link <file:lib/data-cube/project/delete#handler> ] ) ] .

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -4,6 +4,7 @@ import ProjectsView from './views/Projects.vue'
 import ProjectView from './views/Project.vue'
 import ProjectSourcesView from './views/project/Sources.vue'
 import ProjectTablesView from './views/project/Tables.vue'
+import ProjectSettingsView from './views/project/Settings.vue'
 
 Vue.use(Router)
 
@@ -36,6 +37,11 @@ export default new Router({
           path: 'tables',
           name: 'project/tables',
           component: ProjectTablesView
+        },
+        {
+          path: 'edit',
+          name: 'project/edit',
+          component: ProjectSettingsView
         }
       ]
     }

--- a/ui/src/store/common.ts
+++ b/ui/src/store/common.ts
@@ -7,8 +7,8 @@ export async function handleAPIError (context: ActionContext<any, RootState>, f:
   } catch (error) {
     if (error.details) {
       context.commit('storeError', error.details, { root: true })
-    } else {
-      throw error
     }
+
+    throw error
   }
 }

--- a/ui/src/store/modules/projects.ts
+++ b/ui/src/store/modules/projects.ts
@@ -52,9 +52,11 @@ const actions: ActionTree<ProjectsState, RootState> = {
   },
 
   async save (context, { operation, data }) {
-    await handleAPIError(context, async () => {
+    return handleAPIError(context, async () => {
       const project = await client.projects.save(operation, data)
       context.commit('storeOneInList', project)
+      context.commit('storeOne', project)
+      return project
     })
   },
 
@@ -84,7 +86,7 @@ const mutations: MutationTree<ProjectsState> = {
   },
 
   storeOneInList (state, project: Project) {
-    if (!state.projectsList.data) throw new Error('Projects list not loaded')
+    if (!state.projectsList.data) return
 
     state.projectsList.data = state.projectsList.data.filter((p) => p.id !== project.id)
     state.projectsList.data.push(project)

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -1,6 +1,6 @@
 <template>
   <Loader id="project-page" :data="project" v-slot="{ data: project }">
-    <h2 class="title is-2">{{ project.name }}</h2>
+    <h2 class="title is-3">{{ project.name }}</h2>
 
     <div class="tabs">
       <ul>
@@ -12,6 +12,11 @@
         <router-link :to="{ name: 'project/tables' }" v-slot="{ href, route, navigate, isActive }">
           <li :class="[isActive && 'is-active']">
             <a :href="href" @click="navigate">Output tables</a>
+          </li>
+        </router-link>
+        <router-link :to="{ name: 'project/edit' }" v-slot="{ href, route, navigate, isActive }" style="margin-left: auto;">
+          <li :class="[isActive && 'is-active']">
+            <a :href="href" @click="navigate"><b-icon icon="settings" /> Project settings</a>
           </li>
         </router-link>
       </ul>

--- a/ui/src/views/Projects.vue
+++ b/ui/src/views/Projects.vue
@@ -1,36 +1,28 @@
 <template>
   <div id="projects-page">
-    <h2 class="title is-2">My projects</h2>
-
-    <div class="buttons">
-      <b-button type="is-primary" icon-left="plus" @click="showProjectForm(createProject)" v-if="createProject">
-        {{ createProject.title }}
+    <div class="level">
+      <h2 class="title is-3">My projects</h2>
+      <b-button type="is-primary" icon-left="plus" @click="createProject" v-if="createProjectOperation">
+        {{ createProjectOperation.title }}
       </b-button>
     </div>
 
     <Loader :data="projects" v-slot="{ data: projects }">
-      <b-table :data="projects">
-        <template slot-scope="props">
-          <b-table-column field="name" label="Name">
-            <router-link :to="{ name: 'project', params: { id: props.row.id } }">
-              {{ props.row.name }}
-            </router-link>
-          </b-table-column>
-          <b-table-column field label="">
-            <div class="buttons">
-              <b-button icon-left="pencil" v-if="props.row.actions.edit" @click="showProjectForm(props.row.actions.edit, props.row)" />
-              <b-button icon-left="trash-can-outline" v-if="props.row.actions.delete" @click="deleteProject(props.row)" />
-            </div>
-          </b-table-column>
-        </template>
-        <template slot="empty">
-          <section class="section">
-            <div class="content has-text-grey has-text-centered">
-              <p>You don't have any projects yet.</p>
-            </div>
-          </section>
-        </template>
-      </b-table>
+      <ul class="panel" v-if="projects.length > 0">
+        <li v-for="project in projects" :key="project.id" class="panel-block">
+          <router-link :to="{ name: 'project', params: { id: project.id } }">
+            {{ project.name }}
+          </router-link>
+          <router-link :to="{ name: 'project/edit', params: { id: project.id } }" class="button is-white">
+            <b-icon icon="pencil" size="is-small" />
+          </router-link>
+        </li>
+      </ul>
+      <section v-else class="section">
+        <div class="content has-text-grey has-text-centered">
+          <p>You don't have any projects yet.</p>
+        </div>
+      </section>
     </Loader>
   </div>
 </template>
@@ -38,7 +30,6 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import { IOperation } from 'alcaeus/types/Resources'
 import { Project, RemoteData, ProjectFormData } from '@/types'
 import Loader from '../components/Loader.vue'
 import ProjectForm from '../components/project/ProjectForm.vue'
@@ -54,44 +45,33 @@ export default class Projects extends Vue {
     return this.$store.getters['projects/list']
   }
 
-  get createProject (): IOperation | null {
-    return this.$store.state.projects.actions.create
-  }
-
   created () {
     this.$store.dispatch('projects/loadAll')
   }
 
-  showProjectForm (operation: IOperation, project: Project | null = null) {
+  get createProjectOperation () {
+    return this.$store.state.projects.actions.create
+  }
+
+  createProject () {
+    const operation = this.createProjectOperation
     const modal = this.$buefy.modal.open({
       parent: this,
       component: ProjectForm,
       props: {
-        project: project,
         operation: operation,
         save: async (data: ProjectFormData) => {
           const loading = this.$buefy.loading.open({})
-          await this.$store.dispatch('projects/save', { operation, data })
-          loading.close()
-          modal.close()
+          try {
+            const project = await this.$store.dispatch('projects/save', { operation, data })
+            modal.close()
+            this.$router.push({ name: 'project', params: { id: project.id } })
+          } finally {
+            loading.close()
+          }
         }
       },
       hasModalCard: true
-    })
-  }
-
-  deleteProject (project: Project) {
-    this.$buefy.dialog.confirm({
-      title: 'Delete project',
-      message: 'Are you sure you want to delete this project?',
-      confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
-      onConfirm: async () => {
-        const loading = this.$buefy.loading.open({})
-        await this.$store.dispatch('projects/delete', project)
-        loading.close()
-      }
     })
   }
 }

--- a/ui/src/views/project/Settings.vue
+++ b/ui/src/views/project/Settings.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <form class="form" @submit.prevent="save">
+      <b-field label="Name">
+        <b-input v-model="data.name" required />
+      </b-field>
+      <b-field label="Base URI" message="Default prefix for tables and properties">
+        <b-input v-model="data.baseUri" placeholder="https://my-project.example.org" />
+      </b-field>
+
+      <button class="button is-primary">Save settings</button>
+    </form>
+
+  <div class="panel">
+    <b-button type="is-danger" icon-left="trash-can-outline" v-if="project.actions.delete.title" @click="doDelete">
+      {{ project.actions.delete.title }}
+    </b-button>
+  </div>
+  </div>
+</template>
+
+<style scoped>
+.form {
+  max-width: 800px;
+  margin-bottom: 2em;
+}
+</style>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import { Project, ProjectFormData } from '@/types'
+
+@Component
+export default class extends Vue {
+  data: ProjectFormData
+
+  get project (): Project {
+    const projectId = this.$route.params.id
+    const remoteProject = this.$store.getters['projects/one'](projectId)
+    // Assume project is loaded because we're in a nested view
+    return remoteProject.data
+  }
+
+  created () {
+    this.data = {
+      name: this.project.name,
+      baseUri: this.project.baseUri
+    }
+  }
+
+  async save () {
+    const operation = this.project.actions.edit
+    const data = this.data
+    const loading = this.$buefy.loading.open({})
+    try {
+      await this.$store.dispatch('projects/save', { operation, data })
+      this.$buefy.notification.open({ message: 'Settings saved successfully', type: 'is-success' })
+    } finally {
+      loading.close()
+    }
+  }
+
+  doDelete () {
+    this.$buefy.dialog.confirm({
+      title: 'Delete project',
+      message: 'Are you sure you want to delete this project?',
+      confirmText: 'Delete',
+      type: 'is-danger',
+      hasIcon: true,
+      onConfirm: async () => {
+        const loading = this.$buefy.loading.open({})
+        try {
+          await this.$store.dispatch('projects/delete', this.project)
+          this.$router.push({ name: 'projects' })
+        } finally {
+          loading.close()
+        }
+      }
+    })
+  }
+}
+
+</script>


### PR DESCRIPTION
Project settings are now managed in a tab instead of a modal window. This will be better when we add metadata and more settings. It also makes sense to be able to edit a project directly from the project page.