### PR TITLE
fix(csvw): datatype structure as defined in spec

### DIFF
--- a/api/hydra/attributes.ttl
+++ b/api/hydra/attributes.ttl
@@ -29,14 +29,16 @@ dataCube:ValueAttribute
                             hydra:title       "Optional parameters for datatype" ] ,
                           [ hydra:property    dataCube:language ;
                             hydra:title       "Language of the mapped values" ;
-                            hydra:description "Cannot be used together with datatype" ] .
+                            hydra:description "Cannot be used together with datatype" ] ,
+                          [ hydra:property    dataCube:default ;
+                            hydra:title       "Default value" ;
+                            hydra:description "Value used when the transformed table cell is empty" ] .
 
 datatype:parameters rdfs:range dataCube:DatatypeParameters .
 
 dataCube:DatatypeParameters
   a hydra:Class ;
-  hydra:supportedProperty [ hydra:property datatype:format ] ,
-                          [ hydra:property datatype:default ] .
+  hydra:supportedProperty [ hydra:property datatype:format ] .
 
 dataCube:ReferenceAttribute
   rdfs:subclassOf dataCube:Attribute ;

--- a/api/lib/data-cube/table/attributes/Commands.ts
+++ b/api/lib/data-cube/table/attributes/Commands.ts
@@ -34,6 +34,9 @@ export class AddValueAttributeCommand extends AddAttributeCommand {
   }
 
   @property()
+  public default: string;
+
+  @property()
   public language: string;
 
   public get columnId () {

--- a/api/lib/domain/attribute/events.ts
+++ b/api/lib/domain/attribute/events.ts
@@ -5,9 +5,9 @@ export interface AttributeEvents {
     propertyTemplate: string;
     datatype: string;
     language?: string;
+    default?: string;
     parameters: {
       format?: string;
-      default?: string;
     };
   };
   ReferenceAttributeAdded: {

--- a/api/lib/domain/attribute/index.ts
+++ b/api/lib/domain/attribute/index.ts
@@ -9,12 +9,12 @@ export interface ValueAttribute extends Attribute {
   column: string;
   datatype: string;
   language?: string;
+  default?: string;
   parameters: {
     '@context': {
       '@vocab': 'https://rdf-cube-curation.described.at/datatype/';
     };
     format?: string;
-    default?: string;
   };
 }
 

--- a/api/lib/domain/table/__snapshots__/addValueAttribute.spec.ts.snap
+++ b/api/lib/domain/table/__snapshots__/addValueAttribute.spec.ts.snap
@@ -6,9 +6,9 @@ Array [
     "data": Object {
       "columnId": "source/column",
       "datatype": "http://www.w3.org/2001/XMLSchema#string",
+      "default": undefined,
       "language": undefined,
       "parameters": Object {
-        "default": undefined,
         "format": undefined,
       },
       "propertyTemplate": "http://schema.org/name",
@@ -28,12 +28,12 @@ Object {
   ],
   "column": "source/column",
   "datatype": "http://www.w3.org/2001/XMLSchema#string",
+  "default": undefined,
   "language": undefined,
   "parameters": Object {
     "@context": Object {
       "@vocab": "https://rdf-cube-curation.described.at/datatype/",
     },
-    "default": undefined,
     "format": undefined,
   },
   "propertyTemplate": "http://schema.org/name",
@@ -47,9 +47,9 @@ Array [
     "data": Object {
       "columnId": "source/column",
       "datatype": "http://www.w3.org/2001/XMLSchema#date",
+      "default": undefined,
       "language": undefined,
       "parameters": Object {
-        "default": undefined,
         "format": "YYYY/mm/dd",
       },
       "propertyTemplate": "http://schema.org/name",
@@ -69,12 +69,12 @@ Object {
   ],
   "column": "source/column",
   "datatype": "http://www.w3.org/2001/XMLSchema#date",
+  "default": undefined,
   "language": undefined,
   "parameters": Object {
     "@context": Object {
       "@vocab": "https://rdf-cube-curation.described.at/datatype/",
     },
-    "default": undefined,
     "format": "YYYY/mm/dd",
   },
   "propertyTemplate": "http://schema.org/name",

--- a/api/lib/domain/table/addValueAttribute.ts
+++ b/api/lib/domain/table/addValueAttribute.ts
@@ -12,6 +12,7 @@ export interface AddValueAttributeCommand {
   propertyTemplate?: string;
   datatype?: string;
   language?: string;
+  default?: string;
   parameters?: {
     format?: string;
     default?: string;
@@ -42,9 +43,9 @@ export const addValueAttribute = factory<Table, AddValueAttributeCommand, ValueA
     propertyTemplate: command.propertyTemplate,
     datatype: command.datatype || expand('xsd:string'),
     language: command.language,
+    default: command.default,
     parameters: {
       format: command.parameters?.format,
-      default: command.parameters?.default,
     },
   })
 
@@ -56,12 +57,12 @@ export const addValueAttribute = factory<Table, AddValueAttributeCommand, ValueA
     propertyTemplate: command.propertyTemplate,
     datatype: command.datatype || expand('xsd:string'),
     language: command.language,
+    default: command.default,
     parameters: {
       '@context': {
         '@vocab': 'https://rdf-cube-curation.described.at/datatype/',
       },
       format: command.parameters?.format,
-      default: command.parameters?.default,
     },
   }
 

--- a/api/lib/read-graphs/attribute/eventHandlers.ts
+++ b/api/lib/read-graphs/attribute/eventHandlers.ts
@@ -23,6 +23,10 @@ handle<AttributeEvents, 'ValueAttributeAdded'>('ValueAttributeAdded', function a
     }
   })
 
+  if (ev.data.default) {
+    builder.graph(`<${ev.id}> dataCube:default "${ev.data.default}" .`)
+  }
+
   if (ev.data.language) {
     builder.graph(`<${ev.id}> dataCube:language "${ev.data.language}" .`)
   } else if (ev.data.datatype) {

--- a/api/lib/read-model/Table/Attribute.ts
+++ b/api/lib/read-model/Table/Attribute.ts
@@ -20,6 +20,9 @@ function ValueAttributeMixin<TBase extends Constructor<Table.Attribute>> (Base: 
     public datatype: RdfResource
 
     @property.literal()
+    public default: string
+
+    @property.literal()
     public language: string
 
     @property.resource()

--- a/api/lib/read-model/Table/index.ts
+++ b/api/lib/read-model/Table/index.ts
@@ -21,6 +21,7 @@ export interface Attribute extends RdfResource {
 
 export interface ValueAttribute extends Attribute {
   readonly column: Column;
+  readonly default: string;
   readonly language: string;
   readonly datatype: RdfResource;
   readonly parameters: Record<string, string>;

--- a/api/lib/services/__snapshots__/csvwBuilder.spec.ts.snap
+++ b/api/lib/services/__snapshots__/csvwBuilder.spec.ts.snap
@@ -80,6 +80,23 @@ _:c14n4 <http://www.w3.org/ns/csvw#quoteChar> \\"\\\\\\"\\" .
 "
 `;
 
+exports[`csvwBuilder mapping for FactTable maps attribute with default value 1`] = `
+"<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+_:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
+_:c14n1 <http://www.w3.org/ns/csvw#datatype> <http://www.w3.org/2001/XMLSchema#date> .
+_:c14n1 <http://www.w3.org/ns/csvw#default> \\"03/08/1990\\" .
+_:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
+_:c14n1 <http://www.w3.org/ns/csvw#title> \\"station_name\\" .
+_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n1 .
+_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:c14n3 <http://www.w3.org/ns/csvw#delimiter> \\";\\" .
+_:c14n3 <http://www.w3.org/ns/csvw#header> \\"true\\"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:c14n3 <http://www.w3.org/ns/csvw#quoteChar> \\"\\\\\\"\\" .
+"
+`;
+
 exports[`csvwBuilder mapping for FactTable maps attribute with language tag 1`] = `
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .

--- a/api/lib/services/__snapshots__/csvwBuilder.spec.ts.snap
+++ b/api/lib/services/__snapshots__/csvwBuilder.spec.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`csvwBuilder mapping for FactTable does not map as derived type when there are no parameters 1`] = `
+"<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+_:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
+_:c14n1 <http://www.w3.org/ns/csvw#datatype> <http://www.w3.org/2001/XMLSchema#double> .
+_:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
+_:c14n1 <http://www.w3.org/ns/csvw#title> \\"station_name\\" .
+_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n1 .
+_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:c14n3 <http://www.w3.org/ns/csvw#delimiter> \\";\\" .
+_:c14n3 <http://www.w3.org/ns/csvw#header> \\"true\\"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:c14n3 <http://www.w3.org/ns/csvw#quoteChar> \\"\\\\\\"\\" .
+"
+`;
+
 exports[`csvwBuilder mapping for FactTable includes unmapped source columns as suppressed 1`] = `
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
@@ -48,18 +64,19 @@ _:c14n3 <http://www.w3.org/ns/csvw#quoteChar> \\"\\\\\\"\\" .
 
 exports[`csvwBuilder mapping for FactTable maps attribute with datatype parameters 1`] = `
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
-<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n4 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
-_:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
-_:c14n1 <http://www.w3.org/ns/csvw#datatype> <http://www.w3.org/2001/XMLSchema#TOKEN> .
-_:c14n1 <http://www.w3.org/ns/csvw#format> \\"dd/mm/yyyy\\" .
+_:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n3 .
+_:c14n1 <http://www.w3.org/ns/csvw#datatype> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
 _:c14n1 <http://www.w3.org/ns/csvw#title> \\"station_name\\" .
-_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n1 .
-_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:c14n3 <http://www.w3.org/ns/csvw#delimiter> \\";\\" .
-_:c14n3 <http://www.w3.org/ns/csvw#header> \\"true\\"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:c14n3 <http://www.w3.org/ns/csvw#quoteChar> \\"\\\\\\"\\" .
+_:c14n2 <http://www.w3.org/ns/csvw#base> \\"TOKEN\\" .
+_:c14n2 <http://www.w3.org/ns/csvw#format> \\"dd/mm/yyyy\\" .
+_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n1 .
+_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:c14n4 <http://www.w3.org/ns/csvw#delimiter> \\";\\" .
+_:c14n4 <http://www.w3.org/ns/csvw#header> \\"true\\"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+_:c14n4 <http://www.w3.org/ns/csvw#quoteChar> \\"\\\\\\"\\" .
 "
 `;
 

--- a/api/lib/services/csvwBuilder.spec-graphs.ts
+++ b/api/lib/services/csvwBuilder.spec-graphs.ts
@@ -1,4 +1,3 @@
-import { expand } from '@zazuko/rdf-vocabularies'
 import { parseGraph } from '../__tests-helpers__'
 
 export const ids = {
@@ -57,13 +56,6 @@ const columnMappedWithDatatype = `${mappedColumn}
       dataCube:datatype xsd:TOKEN .
 `
 
-const columnMappedWithDatatypeAndParams = `${columnMappedWithDatatype}
-
-<http://example.com/attribute/station_name> <${expand('dataCube:datatype/parameters')}> [
-    <${expand('dataCube:datatype/format')}> "dd/mm/yyyy"
-  ] .
-`
-
 const columnMappedWithLanguage = `${mappedColumn}
 
 <http://example.com/attribute/station_name>
@@ -112,6 +104,5 @@ export const unmappedColumnGraph = parseGraph(unmappedColumn)
 export const mappedColumnGraph = parseGraph(mappedColumn)
 export const multipleMappedColumnsGraph = parseGraph(multipleMappedColumns)
 export const columnMappedWithDatatypeGraph = parseGraph(columnMappedWithDatatype)
-export const columnMappedWithDatatypeAndParamsGraph = parseGraph(columnMappedWithDatatypeAndParams)
 export const columnMappedWithLanguageGraph = parseGraph(columnMappedWithLanguage)
 export const referenceAttributeGraph = parseGraph(referenceAttribute)

--- a/api/lib/services/csvwBuilder.spec.ts
+++ b/api/lib/services/csvwBuilder.spec.ts
@@ -91,6 +91,39 @@ describe('csvwBuilder', () => {
       expect(csvwDataset._node.dataset.toCanonical()).toMatchSnapshot()
     })
 
+    it('maps attribute with default value', async () => {
+      // given
+      const column: Partial<Column> = {
+        id: namedNode('http://example.com/column/station_name'),
+        name: 'station_name',
+      }
+
+      const attribute: RecursivePartial<ValueAttribute> = {
+        id: namedNode('http://example.com/attribute/station_name'),
+        column,
+        propertyTemplate: schema('name').value,
+        datatype: {
+          id: xsd.date,
+        },
+        default: '03/08/1990',
+      }
+      const table: RecursivePartial<Table> = {
+        id: namedNode('http://example.com/table/Observation'),
+        columns: [],
+        attributes: [attribute],
+        types: [
+          dataCube.Table,
+        ],
+      }
+
+      // when
+      const csvwDataset = buildCsvw(table as any)
+
+      // then
+      expect(csvwDataset.tableSchema.columns[0].default).toEqual('03/08/1990')
+      expect(csvwDataset._node.dataset.toCanonical()).toMatchSnapshot()
+    })
+
     it('does not map as derived type when there are no parameters', async () => {
       // given
       const column: Partial<Column> = {

--- a/api/lib/services/csvwBuilder.spec.ts
+++ b/api/lib/services/csvwBuilder.spec.ts
@@ -1,7 +1,7 @@
 import { buildCsvw } from './csvwBuilder'
-import { Column, DimensionTable, ValueAttribute } from '../read-model/Table'
+import { Column, DimensionTable, ValueAttribute, Table } from '../read-model/Table'
 import { namedNode } from '@rdfjs/data-model'
-import { dataCube, xsd } from '../namespaces'
+import { dataCube, schema, xsd } from '../namespaces'
 import * as specGraphs from './csvwBuilder.spec-graphs'
 
 type RecursivePartial<T> = {
@@ -58,10 +58,33 @@ describe('csvwBuilder', () => {
 
     it('maps attribute with datatype parameters', async () => {
       // given
-      const dataset = await specGraphs.columnMappedWithDatatypeAndParamsGraph()
+      const column: Partial<Column> = {
+        id: namedNode('http://example.com/column/station_name'),
+        name: 'station_name',
+      }
+
+      const attribute: RecursivePartial<ValueAttribute> = {
+        id: namedNode('http://example.com/attribute/station_name'),
+        column,
+        propertyTemplate: schema('name').value,
+        datatype: {
+          id: xsd.TOKEN,
+        },
+        parameters: {
+          format: 'dd/mm/yyyy',
+        },
+      }
+      const table: RecursivePartial<Table> = {
+        id: namedNode('http://example.com/table/Observation'),
+        columns: [],
+        attributes: [attribute],
+        types: [
+          dataCube.Table,
+        ],
+      }
 
       // when
-      const csvwDataset = buildCsvw({ dataset, tableId: ids.tableId })
+      const csvwDataset = buildCsvw(table as any)
 
       // then
       expect(csvwDataset._node.dataset.toCanonical()).toMatchSnapshot()

--- a/api/lib/services/csvwBuilder.ts
+++ b/api/lib/services/csvwBuilder.ts
@@ -1,7 +1,6 @@
 import $rdf from 'rdf-ext'
 import { Dataset } from 'rdf-js'
 import cf from 'clownface'
-import { ResourceIndexer } from '@tpluscode/rdfine'
 import { valueAttributeToCsvwColumn } from './csvwBuilder/valueAttribute'
 import { referenceAttributeToCsvwColumn } from './csvwBuilder/referenceAttribute'
 import { error } from '../log'
@@ -15,7 +14,7 @@ import parser = require('uri-template')
 type Attribute = Table.ReferenceAttribute | Table.ValueAttribute | Table.Attribute
 
 function createCsvwColumn (csvwGraph: Csvw.Mapping, table: Table.Table, attribute: Attribute): Csvw.Column | null {
-  let csvwColumn: Csvw.Column & ResourceIndexer | null = null
+  let csvwColumn: Csvw.Column | null = null
 
   if ('column' in attribute) {
     csvwColumn = csvwGraph.newColumn({

--- a/api/lib/services/csvwBuilder/Column.ts
+++ b/api/lib/services/csvwBuilder/Column.ts
@@ -15,6 +15,9 @@ export function ColumnMixin<TBase extends Constructor> (Base: TBase) {
     public datatype: RdfResource;
 
     @property.literal()
+    public default: string;
+
+    @property.literal()
     public valueUrl: string;
 
     @property.literal()

--- a/api/lib/services/csvwBuilder/index.ts
+++ b/api/lib/services/csvwBuilder/index.ts
@@ -5,6 +5,7 @@ export interface Column extends RdfResource {
   propertyUrl: string;
   language: string;
   datatype: RdfResource;
+  default: string;
   valueUrl: string;
   title: string;
 }

--- a/api/lib/services/csvwBuilder/referenceAttribute.ts
+++ b/api/lib/services/csvwBuilder/referenceAttribute.ts
@@ -1,11 +1,10 @@
 import parser from 'uri-template'
-import { ResourceIndexer } from '@tpluscode/rdfine'
 import { error, warning } from '../../log'
 import * as Table from '../../read-model/Table'
 import * as Csvw from '../csvwBuilder/index'
 import { getAbsoluteUrl } from './aboutUrl'
 
-export function referenceAttributeToCsvwColumn (attribute: Table.ReferenceAttribute, csvwColumn: Csvw.Column & ResourceIndexer) {
+export function referenceAttributeToCsvwColumn (attribute: Table.ReferenceAttribute, csvwColumn: Csvw.Column) {
   const referencedTable = attribute.referencedTable
 
   const columnNameMap = attribute.columnMappings

--- a/api/lib/services/csvwBuilder/valueAttribute.ts
+++ b/api/lib/services/csvwBuilder/valueAttribute.ts
@@ -39,6 +39,8 @@ function getBuiltInDatatypeName (datatype: RdfResource): string | null {
 }
 
 export function valueAttributeToCsvwColumn (attribute: Table.ValueAttribute, csvwColumn: Csvw.Column) {
+  csvwColumn.default = attribute.default
+
   if (attribute.language) {
     csvwColumn.language = attribute.language
   } else if (attribute.datatype) {

--- a/api/lib/services/csvwBuilder/valueAttribute.ts
+++ b/api/lib/services/csvwBuilder/valueAttribute.ts
@@ -1,19 +1,63 @@
-import { ResourceIndexer } from '@tpluscode/rdfine'
+import { RdfResource } from '@tpluscode/rdfine'
 import { literal } from '@rdfjs/data-model'
+import { shrink } from '@zazuko/rdf-vocabularies'
 import * as Table from '../../read-model/Table/index'
 import * as Csvw from './index'
-import { csvw } from '../../namespaces'
+import { csvw, rdf } from '../../namespaces'
 
-export function valueAttributeToCsvwColumn (attribute: Table.ValueAttribute, csvwColumn: Csvw.Column & ResourceIndexer) {
-  attribute.parameters && Object.entries(attribute.parameters)
-    .forEach(([param, value]) => {
-      csvwColumn[csvw(param).value] = literal(value)
-    })
+const xsdPrefix = /^xsd:(.+)/
 
+function getBuiltInDatatypeName (datatype: RdfResource): string | null {
+  switch (datatype.id.value) {
+    case (csvw.JSON.value):
+      return 'json'
+    case (rdf.HTML.value):
+      return 'html'
+    case (rdf.XMLLiteral.value):
+      return 'xml'
+  }
+
+  const shrunk = shrink(datatype.id.value)
+  const matches = shrunk.match(xsdPrefix)
+
+  if (!matches) {
+    return null
+  }
+
+  switch (matches[1]) {
+    case 'double':
+      return 'number'
+    case 'base64Binary':
+      return 'binary'
+    case 'dateTime':
+      return 'datetime'
+    case 'anyAtomicType':
+      return 'any'
+  }
+
+  return matches[1]
+}
+
+export function valueAttributeToCsvwColumn (attribute: Table.ValueAttribute, csvwColumn: Csvw.Column) {
   if (attribute.language) {
     csvwColumn.language = attribute.language
   } else if (attribute.datatype) {
-    csvwColumn.datatype = attribute.datatype
+    const builtInType = getBuiltInDatatypeName(attribute.datatype)
+    const hasParameters = attribute.parameters && Object.entries(attribute.parameters).length > 0
+
+    if (builtInType && hasParameters) {
+      const derivedDatatype = csvwColumn._create(csvwColumn._node.blankNode())
+      derivedDatatype[csvw.base.value] = literal(builtInType)
+
+      Object.entries(attribute.parameters)
+        .forEach(([param, value]) => {
+          derivedDatatype[csvw(param).value] = literal(value)
+        })
+
+      csvwColumn.datatype = derivedDatatype
+    } else {
+      csvwColumn.datatype = attribute.datatype
+    }
   }
 
   return csvwColumn

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2904,9 +2904,9 @@
       }
     },
     "@tpluscode/rdfine": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdfine/-/rdfine-0.2.6.tgz",
-      "integrity": "sha512-D7cqbeyXsKBNoMLqJ0KbPzULe/+vIZmFTSJAUNhns05nIroYuh+UYjq+F7AOHnNyp/OKbBkCiRFzwg3Cq+pAkw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdfine/-/rdfine-0.2.7.tgz",
+      "integrity": "sha512-ptSKvAmL+Nm+brChlyNOopt6Gc7UHggIg6qpR96kszJNzCoCsdBjz+zVOeYSrwRsaKbMSGi8NsrkDTOVEmvY5Q==",
       "requires": {
         "@rdfjs/data-model": "^1.1.2",
         "@rdfjs/namespace": "^1.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -28,7 +28,7 @@
     "@fcostarodrigo/walk": "^4.0.2",
     "@tpluscode/fun-ddr": "^0.5.2",
     "@tpluscode/fun-ddr-sparql-graph-repository": "^0.2.9",
-    "@tpluscode/rdfine": "^0.2.6",
+    "@tpluscode/rdfine": "^0.2.7",
     "@zazuko/rdf-vocabularies": "^2019.9.24",
     "aws-sdk": "^2.559.0",
     "body-parser": "^1.19.0",

--- a/api/test/FactTable/CsvwMapping/MapsDatatypeParamsToCsvwTerms.hydra
+++ b/api/test/FactTable/CsvwMapping/MapsDatatypeParamsToCsvwTerms.hydra
@@ -76,9 +76,9 @@ With Class dataCube:Table {
         Expect Property csvw:tableSchema {
             Expect Property csvw:column {
                 Expect Property csvw:datatype {
-                    Expect Id <http://www.w3.org/2001/XMLSchema#date>
+                    Expect Property csvw:base "date"
+                    Expect Property csvw:format "dd/MM/yyyy"
                 }
-                Expect Property csvw:format "dd/MM/yyyy"
                 Expect Property csvw:default "10/10/2010"
             }
         }
@@ -98,9 +98,9 @@ With Operation api:AddValueAttribute {
         <> dataCube:column <project/parametrized-datatype-test/source/single-column-csv/station-id> ;
            dataCube:propertyTemplate <http://schema.org/identifier> ;
            dataCube:datatype xsd:date ;
+           dataCube:default "10/10/2010" ;
            datatype:parameters [
               datatype:format "dd/MM/yyyy" ;
-              datatype:default "10/10/2010" ;
            ] ;
            a dataCube:ValueAttribute .
         ```
@@ -110,7 +110,7 @@ With Operation api:AddValueAttribute {
 
         Expect Property datatype:parameters {
             Expect Property datatype:format "dd/MM/yyyy"
-            Expect Property datatype:default "10/10/2010"
         }
+        Expect Property dataCube:default "10/10/2010"
     }
 }


### PR DESCRIPTION
- [x] types with parameters produce "Derived Datatypes"
- [x] datatype URI mapped to their respective CSVW shorthand names
- [x] `default` should be property of attribute and not datatype