### PR TITLE
fix: csvw document does not include the url property

### DIFF
--- a/api/lib/read-model/Project.ts
+++ b/api/lib/read-model/Project.ts
@@ -1,4 +1,4 @@
-import { Constructor, property, RdfResource, RdfResourceImpl } from '@tpluscode/rdfine'
+import { Constructor, property, RdfResource } from '@tpluscode/rdfine'
 import { dataCube, schema } from '../namespaces'
 import * as DataCube from '.'
 
@@ -17,5 +17,3 @@ export function ProjectMixin<TBase extends Constructor> (Base: TBase) {
 ProjectMixin.shouldApply = (node: RdfResource) => {
   return node.hasType(dataCube.Project)
 }
-
-RdfResourceImpl.factory.addMixin(ProjectMixin)

--- a/api/lib/read-model/Source.ts
+++ b/api/lib/read-model/Source.ts
@@ -1,0 +1,11 @@
+import { property, Constructor } from '@tpluscode/rdfine'
+import { schema } from '../namespaces'
+
+export function SourceMixin<Base extends Constructor> (base: Base) {
+  class Source extends base {
+    @property.literal({ path: schema.name })
+    public name!: string;
+  }
+
+  return Source
+}

--- a/api/lib/read-model/Table/Attribute.ts
+++ b/api/lib/read-model/Table/Attribute.ts
@@ -1,4 +1,4 @@
-import { Constructor, namespace, property, RdfResource, RdfResourceImpl } from '@tpluscode/rdfine'
+import { Constructor, namespace, property, RdfResource } from '@tpluscode/rdfine'
 import * as Table from './index'
 import { dataCube } from '../../namespaces'
 import './ColumnMapping'
@@ -71,6 +71,8 @@ ReferenceAttributeMixin.shouldApply = (cf: RdfResource) => {
   return cf.hasType(dataCube.ReferenceAttribute)
 }
 
-RdfResourceImpl.factory.addMixin(AttributeMixin)
-RdfResourceImpl.factory.addMixin(ValueAttributeMixin)
-RdfResourceImpl.factory.addMixin(ReferenceAttributeMixin)
+export default [
+  AttributeMixin,
+  ValueAttributeMixin,
+  ReferenceAttributeMixin,
+]

--- a/api/lib/read-model/Table/Column.ts
+++ b/api/lib/read-model/Table/Column.ts
@@ -1,8 +1,8 @@
-import { Constructor, RdfResource, RdfResourceImpl, property } from '@tpluscode/rdfine'
+import { Constructor, RdfResource, property } from '@tpluscode/rdfine'
 import * as Table from './index'
 import { dataCube, schema } from '../../namespaces'
 
-function ColumnMixin<TBase extends Constructor> (Base: TBase) {
+export function ColumnMixin<TBase extends Constructor> (Base: TBase) {
   class Column extends Base implements Table.Column {
     @property.literal({ path: schema.name })
     public name: string
@@ -14,5 +14,3 @@ function ColumnMixin<TBase extends Constructor> (Base: TBase) {
 ColumnMixin.shouldApply = (node: RdfResource) => {
   return node.hasType(dataCube.Column)
 }
-
-RdfResourceImpl.factory.addMixin(ColumnMixin)

--- a/api/lib/read-model/Table/ColumnMapping.ts
+++ b/api/lib/read-model/Table/ColumnMapping.ts
@@ -1,9 +1,9 @@
-import { Constructor, namespace, property, RdfResourceImpl, RdfResource } from '@tpluscode/rdfine'
+import { Constructor, namespace, property, RdfResource } from '@tpluscode/rdfine'
 import * as Table from './index'
 import { dataCube } from '../../namespaces'
 import './Column'
 
-function ColumnMappingMixin<TBase extends Constructor> (Base: TBase) {
+export function ColumnMappingMixin<TBase extends Constructor> (Base: TBase) {
   @namespace(dataCube)
   class ColumnMapping extends Base implements Table.ColumnMapping {
     @property.resource()
@@ -18,5 +18,3 @@ function ColumnMappingMixin<TBase extends Constructor> (Base: TBase) {
 
 ColumnMappingMixin.shouldApply = (term: RdfResource) =>
   term._node.out([ dataCube.referencedColumn, dataCube.sourceColumn ]).terms.length > 1
-
-RdfResourceImpl.factory.addMixin(ColumnMappingMixin)

--- a/api/lib/read-model/Table/Table.ts
+++ b/api/lib/read-model/Table/Table.ts
@@ -4,6 +4,7 @@ import { dataCube, rdf } from '../../namespaces'
 import './Attribute'
 import { ProjectMixin } from '../Project'
 import * as DataCube from '../'
+import { SourceMixin } from '../Source'
 
 @namespace(dataCube)
 export class BaseTable extends RdfResourceImpl implements Table.Table {
@@ -12,6 +13,9 @@ export class BaseTable extends RdfResourceImpl implements Table.Table {
 
   @property.resource({ path: dataCube.project, as: [ ProjectMixin ] })
   public readonly project: DataCube.Project
+
+  @property.resource({ path: dataCube.source, as: [ SourceMixin ] })
+  public readonly source: DataCube.Source
 
   public get attributes () {
     return this._node.in(dataCube.table)
@@ -22,7 +26,7 @@ export class BaseTable extends RdfResourceImpl implements Table.Table {
   }
 }
 
-function DimensionTableMixin<TBase extends Constructor<BaseTable>> (Base: TBase) {
+export function DimensionTableMixin<TBase extends Constructor<BaseTable>> (Base: TBase) {
   @namespace(dataCube)
   class DimensionTable extends Base implements Table.DimensionTable {
     @property.literal()
@@ -35,5 +39,3 @@ function DimensionTableMixin<TBase extends Constructor<BaseTable>> (Base: TBase)
 DimensionTableMixin.shouldApply = (node: RdfResource) => {
   return node.hasType(dataCube.DimensionTable)
 }
-
-RdfResourceImpl.factory.addMixin(DimensionTableMixin)

--- a/api/lib/read-model/Table/index.ts
+++ b/api/lib/read-model/Table/index.ts
@@ -1,10 +1,11 @@
 import { RdfResource } from '@tpluscode/rdfine'
-import { Project } from '../'
+import { Project, Source } from '../'
 
 export interface Table extends RdfResource {
   readonly columns: Column[];
   readonly attributes: Attribute[];
   readonly project: Project;
+  readonly source: Source;
 }
 
 export interface DimensionTable extends Table {

--- a/api/lib/read-model/index.ts
+++ b/api/lib/read-model/index.ts
@@ -4,3 +4,7 @@ export interface Project extends RdfResource {
   name: string;
   baseUri: string;
 }
+
+export interface Source extends RdfResource {
+  readonly name: string;
+}

--- a/api/lib/read-model/wireUp.ts
+++ b/api/lib/read-model/wireUp.ts
@@ -1,0 +1,18 @@
+import { ResourceFactory } from '@tpluscode/rdfine'
+import { ProjectMixin } from './Project'
+import { DimensionTableMixin } from './Table/Table'
+import { SourceMixin } from './Source'
+import Attributes from './Table/Attribute'
+import { ColumnMixin } from './Table/Column'
+import { ColumnMappingMixin } from './Table/ColumnMapping'
+
+export default function (factory: ResourceFactory) {
+  [
+    ...Attributes,
+    ProjectMixin,
+    DimensionTableMixin,
+    SourceMixin,
+    ColumnMixin,
+    ColumnMappingMixin,
+  ].forEach(m => factory.addMixin(m))
+}

--- a/api/lib/services/__snapshots__/csvwBuilder.spec.ts.snap
+++ b/api/lib/services/__snapshots__/csvwBuilder.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`csvwBuilder mapping for FactTable does not map as derived type when the
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"test.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#datatype> <http://www.w3.org/2001/XMLSchema#double> .
 _:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
@@ -20,6 +21,7 @@ exports[`csvwBuilder mapping for FactTable includes unmapped source columns as s
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"UBD0028.Daten_de.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#suppressOutput> \\"true\\"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 _:c14n1 <http://www.w3.org/ns/csvw#title> \\"station_name\\" .
@@ -35,6 +37,7 @@ exports[`csvwBuilder mapping for FactTable maps attribute 1`] = `
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"UBD0028.Daten_de.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
 _:c14n1 <http://www.w3.org/ns/csvw#title> \\"station_name\\" .
@@ -50,6 +53,7 @@ exports[`csvwBuilder mapping for FactTable maps attribute with datatype 1`] = `
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"UBD0028.Daten_de.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#datatype> <http://www.w3.org/2001/XMLSchema#TOKEN> .
 _:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
@@ -66,6 +70,7 @@ exports[`csvwBuilder mapping for FactTable maps attribute with datatype paramete
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n4 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"test.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n3 .
 _:c14n1 <http://www.w3.org/ns/csvw#datatype> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
@@ -84,6 +89,7 @@ exports[`csvwBuilder mapping for FactTable maps attribute with default value 1`]
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"test.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#datatype> <http://www.w3.org/2001/XMLSchema#date> .
 _:c14n1 <http://www.w3.org/ns/csvw#default> \\"03/08/1990\\" .
@@ -101,6 +107,7 @@ exports[`csvwBuilder mapping for FactTable maps attribute with language tag 1`] 
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n3 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"UBD0028.Daten_de.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n2 .
 _:c14n1 <http://www.w3.org/ns/csvw#lang> \\"en\\" .
 _:c14n1 <http://www.w3.org/ns/csvw#propertyUrl> \\"http://schema.org/name\\" .
@@ -117,6 +124,7 @@ exports[`csvwBuilder mapping for FactTable maps multiple attributes mapping same
 "<http://example.com/table/Observation/csvw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/csvw#CsvwMapping> .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#dialect> _:c14n5 .
 <http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#tableSchema> _:c14n0 .
+<http://example.com/table/Observation/csvw> <http://www.w3.org/ns/csvw#url> \\"UBD0028.Daten_de.csv\\" .
 _:c14n0 <http://www.w3.org/ns/csvw#column> _:c14n1 .
 _:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:c14n2 .
 _:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:c14n3 .

--- a/api/lib/services/csvwBuilder.spec.ts
+++ b/api/lib/services/csvwBuilder.spec.ts
@@ -82,6 +82,9 @@ describe('csvwBuilder', () => {
         types: [
           dataCube.Table,
         ],
+        source: {
+          name: 'test.csv',
+        },
       }
 
       // when
@@ -114,6 +117,9 @@ describe('csvwBuilder', () => {
         types: [
           dataCube.Table,
         ],
+        source: {
+          name: 'test.csv',
+        },
       }
 
       // when
@@ -148,6 +154,9 @@ describe('csvwBuilder', () => {
         types: [
           dataCube.Table,
         ],
+        source: {
+          name: 'test.csv',
+        },
       }
 
       // when
@@ -194,6 +203,9 @@ describe('csvwBuilder', () => {
             types: [
               dataCube.Table,
             ],
+            source: {
+              name: 'test.csv',
+            },
           }
 
           // when
@@ -242,6 +254,9 @@ describe('csvwBuilder', () => {
         project: {
           baseUri: 'http://example.com/tst-project',
         },
+        source: {
+          name: 'test.csv',
+        },
       }
 
       // when
@@ -263,6 +278,9 @@ describe('csvwBuilder', () => {
         ],
         project: {
           baseUri: 'http://example.com/tst-project/',
+        },
+        source: {
+          name: 'test.csv',
         },
       }
 
@@ -295,6 +313,9 @@ describe('csvwBuilder', () => {
         ],
         project: {
           baseUri: 'http://example.com/tst-project/',
+        },
+        source: {
+          name: 'test.csv',
         },
       }
 

--- a/api/lib/services/csvwBuilder.ts
+++ b/api/lib/services/csvwBuilder.ts
@@ -1,6 +1,7 @@
 import $rdf from 'rdf-ext'
 import { Dataset } from 'rdf-js'
 import cf from 'clownface'
+import { RdfResourceImpl } from '@tpluscode/rdfine'
 import { valueAttributeToCsvwColumn } from './csvwBuilder/valueAttribute'
 import { referenceAttributeToCsvwColumn } from './csvwBuilder/referenceAttribute'
 import { error } from '../log'
@@ -9,9 +10,12 @@ import * as Table from '../read-model/Table'
 import { BaseTable } from '../read-model/Table/Table'
 import * as Csvw from './csvwBuilder/index'
 import { getAbsoluteUrl } from './csvwBuilder/aboutUrl'
+import wireUp from '../read-model/wireUp'
 import parser = require('uri-template')
 
 type Attribute = Table.ReferenceAttribute | Table.ValueAttribute | Table.Attribute
+
+wireUp(RdfResourceImpl.factory)
 
 function createCsvwColumn (csvwGraph: Csvw.Mapping, table: Table.Table, attribute: Attribute): Csvw.Column | null {
   let csvwColumn: Csvw.Column | null = null
@@ -58,6 +62,7 @@ export function buildCsvw (tableOrDataset: Table.Table | Table.DimensionTable | 
   const csvwGraph = new CsvwGraph({ dataset: $rdf.dataset(), term: $rdf.namedNode(`${table.id.value}/csvw`) })
 
   csvwGraph.addDialect()
+  csvwGraph.url = table.source.name
 
   if ('identifierTemplate' in table) {
     const parsed = parser.parse(table.identifierTemplate)

--- a/api/lib/services/csvwBuilder/Csvw.ts
+++ b/api/lib/services/csvwBuilder/Csvw.ts
@@ -1,4 +1,4 @@
-import { RdfResourceImpl } from '@tpluscode/rdfine'
+import { namespace, RdfResourceImpl, property } from '@tpluscode/rdfine'
 import { csvw, rdf } from '../../namespaces'
 import * as Csvw from './index'
 import { TableSchema } from './TableSchema'
@@ -6,7 +6,11 @@ import { BlankNode, DatasetCore, NamedNode } from 'rdf-js'
 import { ColumnMixin } from './Column'
 import { SingleContextClownface, Clownface } from 'clownface'
 
+@namespace(csvw)
 export default class <D extends DatasetCore> extends RdfResourceImpl<D> implements Csvw.Mapping {
+  @property.literal()
+  public url!: string
+
   public constructor (o: { dataset: D; term: NamedNode }) {
     super(o)
 

--- a/api/lib/services/csvwBuilder/index.ts
+++ b/api/lib/services/csvwBuilder/index.ts
@@ -19,4 +19,5 @@ export interface Mapping extends RdfResource {
   newColumn(col: { name: string }): Column & ResourceIndexer;
   addDialect(): void;
   readonly tableSchema: TableSchema;
+  url: string;
 }


### PR DESCRIPTION
Adding the `csvw:url` property which is necessary to match the input files being processed with a table's mapping