### PR TITLE
feat: fail when a csv has empty column names

### DIFF
--- a/api/lib/domain/project/createSource.spec.ts
+++ b/api/lib/domain/project/createSource.spec.ts
@@ -1,0 +1,67 @@
+import { createSource } from './createSource'
+import { DomainError } from '@tpluscode/fun-ddr'
+import { Project } from './index'
+
+describe('source', () => {
+  describe('create', () => {
+    it('returns error when any column is empty string', async () => {
+      // given
+      const command = {
+        fileName: 'animals.csv',
+        type: 'csv' as const,
+        sample: [],
+        columns: ['foo', 'bar', ''],
+      }
+      const project: Partial<Project> = {
+        '@id': '/project/foo',
+        '@type': 'Project',
+      }
+
+      // when
+      const result = await createSource(project as any, command)
+
+      // then
+      await expect(result.error).resolves.toBeInstanceOf(DomainError)
+    })
+
+    it('returns error when any column is whitespace', async () => {
+      // given
+      const command = {
+        fileName: 'animals.csv',
+        type: 'csv' as const,
+        sample: [],
+        columns: ['foo', 'bar', ' '],
+      }
+      const project: Partial<Project> = {
+        '@id': '/project/foo',
+        '@type': 'Project',
+      }
+
+      // when
+      const result = await createSource(project as any, command)
+
+      // then
+      await expect(result.error).resolves.toBeInstanceOf(DomainError)
+    })
+
+    it('returns error when any column is null', async () => {
+      // given
+      const command = {
+        fileName: 'animals.csv',
+        type: 'csv' as const,
+        sample: [],
+        columns: ['foo', 'bar', null],
+      }
+      const project: Partial<Project> = {
+        '@id': '/project/foo',
+        '@type': 'Project',
+      }
+
+      // when
+      const result = await createSource(project as any, command as any)
+
+      // then
+      await expect(result.error).resolves.toBeInstanceOf(DomainError)
+    })
+  })
+})

--- a/api/lib/domain/project/createSource.ts
+++ b/api/lib/domain/project/createSource.ts
@@ -1,4 +1,4 @@
-import { factory } from '@tpluscode/fun-ddr'
+import { DomainError, factory } from '@tpluscode/fun-ddr'
 import slug from 'url-slug'
 import { Source } from '../source'
 import { SourceEvents } from '../source/events'
@@ -12,6 +12,10 @@ interface UploadSourceCommand {
 }
 
 export const createSource = factory<Project, UploadSourceCommand, Source>(function (project, command, emitter) {
+  if (command.columns.findIndex(column => !column || column.trim() === '') > 0) {
+    throw new DomainError(project['@id'], 'Cannot create source', 'Columns names cannot be empty')
+  }
+
   const sourceId = `${project['@id']}/source/${slug(command.fileName)}`
 
   emitter.emit<SourceEvents, 'SourceUploaded'>('SourceUploaded', {

--- a/api/lib/domain/project/createSource.ts
+++ b/api/lib/domain/project/createSource.ts
@@ -12,7 +12,7 @@ interface UploadSourceCommand {
 }
 
 export const createSource = factory<Project, UploadSourceCommand, Source>(function (project, command, emitter) {
-  if (command.columns.findIndex(column => !column || column.trim() === '') > 0) {
+  if (command.columns.some(column => !column || column.trim() === '')) {
     throw new DomainError(project['@id'], 'Cannot create source', 'Columns names cannot be empty')
   }
 


### PR DESCRIPTION
As discussed with @ktk, the API will immediately reject CSV where a column is empty (or all-whitespace)