### PR TITLE
feat(ui): add a way to get a project's URI

### DIFF
--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -78,8 +78,7 @@ export default class ProjectView extends Vue {
 
     if (!inputElement) { return }
 
-    inputElement.select()
-    const success = document.execCommand('copy')
+    const success = copyInputContentToClipboard(inputElement)
 
     if (success) {
       this.$buefy.toast.open({
@@ -93,5 +92,18 @@ export default class ProjectView extends Vue {
       })
     }
   }
+}
+
+function copyInputContentToClipboard (input: HTMLInputElement): boolean {
+  input.select()
+
+  let success
+  try {
+    success = document.execCommand('copy')
+  } catch (e) {
+    success = false
+  }
+
+  return success
 }
 </script>

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -87,8 +87,8 @@ export default class ProjectView extends Vue {
       })
     } else {
       this.$buefy.toast.open({
-        message: 'Error: could not copy project URI',
-        type: 'is-danger'
+        message: 'Sorry, your browser is not very cooperative. You\'ll have to hit CMD/CTRL+C manually.',
+        type: 'is-warning'
       })
     }
   }

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -1,6 +1,18 @@
 <template>
   <Loader id="project-page" :data="project" v-slot="{ data: project }">
-    <h2 class="title is-3">{{ project.name }}</h2>
+    <div class="level">
+      <div class="level-left">
+        <h2 class="level-item title is-3">{{ project.name }}</h2>
+      </div>
+      <div class="level-right">
+        <b-field class="level-item">
+          <b-tooltip label="Project URI" type="is-light" position="is-left" :delay="100" class="control">
+            <b-input ref="uriInput" size="is-small" :value="project.id" :readonly="true" />
+          </b-tooltip>
+          <b-button size="is-small" icon-left="clipboard" title="Copy to clipboard" @click="copyProjectURI" />
+        </b-field>
+      </div>
+    </div>
 
     <div class="tabs">
       <ul>
@@ -57,6 +69,28 @@ export default class ProjectView extends Vue {
       } else {
         throw e
       }
+    }
+  }
+
+  copyProjectURI () {
+    const inputComponent = this.$refs.uriInput as Vue
+    const inputElement = inputComponent?.$el.querySelector('input')
+
+    if (!inputElement) { return }
+
+    inputElement.select()
+    const success = document.execCommand('copy')
+
+    if (success) {
+      this.$buefy.toast.open({
+        message: 'The project URI was copied to your clipboard',
+        type: 'is-success'
+      })
+    } else {
+      this.$buefy.toast.open({
+        message: 'Error: could not copy project URI',
+        type: 'is-danger'
+      })
     }
   }
 }


### PR DESCRIPTION
Since we need a project's URI to use the CLI, it probably makes sense to offer a way to get it.

This adds a field that displays the project's URI and a button to copy it to the clipboard (Github-like).