### PR TITLE
fix: request model was not being correctly determined

### DIFF
--- a/api/lib/express.ts
+++ b/api/lib/express.ts
@@ -37,7 +37,8 @@ export function modelBuilder (req: Request, res, next: NextFunction) {
       }, RdfResourceImpl)
     } else {
       if (modelShape.types && modelShape.types.some(Boolean)) {
-        graph = graph
+        const allSubjects = cf({ dataset: req.graph }).in()
+        graph = allSubjects
           .has(rdf.type, modelShape.types)
       }
 


### PR DESCRIPTION
When there is a class with expected type URIs, we might reflect on all subjects in the request and find ones with the @type
