### PR TITLE
fix(ui): infinite loader on API error

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -45,6 +45,7 @@
     position: fixed;
     bottom: 1em;
     right: 1em;
+    z-index: 50;
   }
 </style>
 

--- a/ui/src/components/project/SourceItem.vue
+++ b/ui/src/components/project/SourceItem.vue
@@ -184,8 +184,11 @@ export default class extends Vue {
       hasIcon: true,
       onConfirm: async () => {
         const loading = this.$buefy.loading.open({})
-        await this.$store.dispatch('sources/delete', source)
-        loading.close()
+        try {
+          await this.$store.dispatch('sources/delete', source)
+        } finally {
+          loading.close()
+        }
       },
     })
   }

--- a/ui/src/components/project/TableItem.vue
+++ b/ui/src/components/project/TableItem.vue
@@ -249,9 +249,12 @@ export default class extends Vue {
         source: this.source,
         save: async (attribute: ValueAttributeFormData) => {
           const loading = this.$buefy.loading.open({})
-          await this.$store.dispatch('attributes/createValue', { table: this.table, attribute })
-          loading.close()
-          modal.close()
+          try {
+            await this.$store.dispatch('attributes/createValue', { table: this.table, attribute })
+            modal.close()
+          } finally {
+            loading.close()
+          }
         },
       },
       hasModalCard: true,
@@ -271,9 +274,12 @@ export default class extends Vue {
         sources: this.sources,
         save: async (attribute: ReferenceAttributeFormData) => {
           const loading = this.$buefy.loading.open({})
-          await this.$store.dispatch('attributes/createReference', { table: this.table, attribute })
-          loading.close()
-          modal.close()
+          try {
+            await this.$store.dispatch('attributes/createReference', { table: this.table, attribute })
+            modal.close()
+          } finally {
+            loading.close()
+          }
         },
       },
       hasModalCard: true,
@@ -289,8 +295,11 @@ export default class extends Vue {
       hasIcon: true,
       onConfirm: async () => {
         const loading = this.$buefy.loading.open({})
-        await this.$store.dispatch('attributes/delete', attribute)
-        loading.close()
+        try {
+          await this.$store.dispatch('attributes/delete', attribute)
+        } finally {
+          loading.close()
+        }
       },
     })
   }


### PR DESCRIPTION
In some cases, the loader would get stuck when an API error occurred.

The error message would also show up *under* the modal.

Fix #234 