### PR TITLE
fix(ui): issue with native form validation pattern on Firefox

### DIFF
--- a/ui/src/components/IdentifierTemplateField.vue
+++ b/ui/src/components/IdentifierTemplateField.vue
@@ -1,13 +1,13 @@
 <template>
-  <b-field label="Identifier attribute template" :message="message">
+  <b-field label="Identifier attribute template" :message="message" :type="{ 'is-danger': !isValid }">
     <b-autocomplete
         ref="autocomplete"
         :value="value"
         @input="onUpdate"
         @typing="onTyping"
         @select="onSelect"
+        @blur="validate"
         :data="propositions"
-        :pattern="validationPattern"
         :custom-formatter="formatProposition"
         placeholder="e.g. my-table/{column_id}"
         :disabled="!source"
@@ -29,6 +29,7 @@ export default class extends Vue {
   @Prop() tableName: string
   @Prop() source: Source
   wasModified = false;
+  isValid = true;
 
   onUpdate (newValue: string) {
     this.$emit('input', newValue)
@@ -95,16 +96,8 @@ export default class extends Vue {
     return columns.map(({ name }) => name)
   }
 
-  get validationPattern () {
-    const columnNamesPattern = this.columnNames.join('|')
-    return `([^{}]*(\\{(${columnNamesPattern})\\})?[^{}]*)*`
-  }
-
   get invalidMessage () {
-    const input = this.getAutocompleteComponent()?.$refs.input as any
-    if (!this.value || !input || input.isValid) {
-      return null
-    }
+    if (!this.value) return null
 
     const matches = this.value.matchAll(/\{([^{}]*)\}/g) ?? []
     const inputColumnNames = [...matches].map((match) => match[1])
@@ -113,8 +106,13 @@ export default class extends Vue {
     if (invalidColumnNames.length > 0) {
       return `The following columns are not valid: ${invalidColumnNames.join(', ')}`
     } else {
-      return 'Invalid value'
+      return null
     }
+  }
+
+  validate () {
+    const input = this.getAutocompleteComponent()?.$refs.input as any
+    this.isValid = input?.checkHtml5Validity() && !this.invalidMessage
   }
 
   get expandedValue () {


### PR DESCRIPTION
It seems like the implementation of pattern validation in Firefox is less efficient than in Chrome and crashes the app when we abuse it with a long pattern and a long input.

I switched to a manual validation... which is probably a better solution in the end. Although it has the downside of not preventing you from submitting the form. It is not really an issue because the error message that comes back from the API is pretty clear as well.

We should look into a proper validation library (e.g. vee-validate) at some point.

Fixes #228 