### PR TITLE
Load datacube metadata

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -11,7 +11,7 @@ const ns = {
 }
 
 const pipelines = {
-  TransformFiles: ns.pipeline('#TransformFiles'),
+  TransformFiles: ns.pipeline('#Main'),
 }
 
 function parseVariables (str, all) {

--- a/packages/cli/lib/commands/transform.ts
+++ b/packages/cli/lib/commands/transform.ts
@@ -32,6 +32,7 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
     const pipelinePath = filename => path.join(basePath, `./pipelines/${filename}.ttl`)
     const dataset = $rdf.dataset()
       .merge(await fileToDataset('text/turtle', pipelinePath('main')))
+      .merge(await fileToDataset('text/turtle', pipelinePath('datacube-metadata')))
       .merge(await fileToDataset('text/turtle', pipelinePath(`from-${from}`)))
       .merge(await fileToDataset('text/turtle', pipelinePath(`to-${to}`)))
 

--- a/packages/cli/lib/datacube-metadata.ts
+++ b/packages/cli/lib/datacube-metadata.ts
@@ -1,0 +1,134 @@
+import path from 'path'
+import fs from 'fs'
+import through from 'through2'
+import reduce from 'through2-reduce'
+import aws from 'aws-sdk'
+import clownface from 'clownface'
+import $rdf from 'rdf-ext'
+import { Context } from 'barnard59-core/lib/Pipeline'
+import toReadable from 'barnard59-base/lib/toReadable'
+import { qb, rdf } from '@zazuko/rdfine-data-cube/namespaces'
+
+const filename = 'datacube-metadata.ttl'
+
+export function openFile (this: Context, sourceDir: string) {
+  const filePath = path.resolve(sourceDir, filename)
+
+  if (fs.existsSync(filePath)) {
+    return fs.createReadStream(filePath)
+  } else {
+    this.log.warn('Datacube metadata file not found')
+    return toReadable.string('')
+  }
+}
+
+export async function openFileFromS3 (this: Context, s3Endpoint: string, s3Bucket: string) {
+  this.log.info(`Opening file ${filename} from S3`)
+
+  const s3 = new aws.S3({ endpoint: s3Endpoint })
+
+  let content
+  try {
+    const response = await s3.getObject({
+      Bucket: s3Bucket,
+      Key: filename,
+    }).promise()
+    content = response.Body?.toString()
+  } catch (error) {
+    if (error.code === 'NoSuchKey') {
+      this.log.warn('Datacube metadata file not found')
+      content = ''
+    } else {
+      if (error.stack) {
+        this.log.error(error.stack)
+      }
+      throw new Error(`Error reading file "${filename}" from S3`)
+    }
+  }
+
+  return toReadable.string(content)
+}
+
+export function accumulateToDataset () {
+  return reduce({ objectMode: true }, (dataset, quad) => {
+    dataset.add(quad)
+    return dataset
+  }, $rdf.dataset())
+}
+
+// Generate proper qb:DataSet metadata
+export function generate () {
+  return through.obj(function (this, dataset, encoding, callback) {
+    const cf = clownface({ dataset })
+    let datacube = cf.namedNode(qb.DataSet).in(rdf.type).term
+
+    if (!datacube) {
+      datacube = cf.namedNode(qb.DataSet).addIn(rdf.type, cf.blankNode()).term
+    }
+
+    const structure = cf.namedNode(datacube as any)
+      .addOut(qb.structure, cf.blankNode())
+      .out(qb.structure)
+      .addOut(rdf.type, qb.DataStructureDefinition)
+      .term
+
+    cf.node(qb.MeasureProperty).in(rdf.type).forEach((measure) => {
+      const component = cf.blankNode().term
+      cf.node(structure as any)
+        .addOut(qb.component, component)
+      cf.node(component)
+        .addOut(rdf.type, qb.ComponentSpecification)
+        .addOut(qb.measure, measure.term)
+    })
+
+    cf.node(qb.DimensionProperty).in(rdf.type).forEach((dimension) => {
+      const component = cf.blankNode().term
+      cf.node(structure as any)
+        .addOut(qb.component, component)
+      cf.node(component)
+        .addOut(rdf.type, qb.ComponentSpecification)
+        .addOut(qb.dimension, dimension.term)
+    })
+
+    cf.node(qb.AttributeProperty).in(rdf.type).forEach((attribute) => {
+      const component = cf.blankNode().term
+      cf.node(structure as any)
+        .addOut(qb.component, component)
+      cf.node(component)
+        .addOut(rdf.type, qb.ComponentSpecification)
+        .addOut(qb.attribute, attribute.term)
+    })
+
+    for (const quad of dataset) {
+      this.push(quad)
+    }
+
+    callback()
+  })
+}
+
+export function linkObservationsToDataset (this: Context) {
+  const context = this // eslint-disable-line @typescript-eslint/no-this-alias
+
+  return through.obj(function (this: any, quad, encoding, callback) {
+    // Intercept qb:DataSet node and store it in a variable
+    if (quad.predicate.equals(rdf.type) && quad.object.equals(qb.DataSet)) {
+      context.variables.set('datacubeNode', quad.subject)
+    }
+
+    // Link observations to the previously intercepted qb:DataSet
+    if (quad.predicate.equals(rdf.type) && quad.object.equals(qb.Observation)) {
+      const datacube = context.variables.get('datacubeNode')
+
+      if (!datacube) {
+        throw new Error('`qb:DataSet` not found in datacube metadata')
+      }
+
+      this.push($rdf.quad(quad.subject, qb.dataSet, datacube))
+    }
+
+    this.push(quad)
+
+    callback()
+  })
+}

--- a/packages/cli/lib/project.ts
+++ b/packages/cli/lib/project.ts
@@ -66,6 +66,7 @@ class ProjectIterator extends stream.Readable {
               }
 
               log.debug(`Will transform table ${table.name} from ${csvwResource.url}. Dialect: delimiter=${csvwResource.dialect.delimiter} quote=${csvwResource.dialect.quote}`)
+
               this.push(csvwResource)
             })
             .catch(e => {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2909,6 +2909,17 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
 			}
 		},
 		"exit": {
@@ -3841,10 +3852,9 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"dev": true,
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+			"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
 			"requires": {
 				"pump": "^3.0.0"
 			}
@@ -6205,7 +6215,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1267,9 +1267,9 @@
 			}
 		},
 		"barnard59-base": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/barnard59-base/-/barnard59-base-0.0.1.tgz",
-			"integrity": "sha512-nerc7N7xBMVKGOajbSi1yNXGawS6z02UAo79UhLOaA7/Nn9LbUF/IzxTivXc4fatb7dE4qM8yKaaeYTj+sbjNQ==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/barnard59-base/-/barnard59-base-0.0.3.tgz",
+			"integrity": "sha512-in3CHC4mIitbP0bBqrMh2a+z8ntkXr15BohmM2egPPrWRXBIyYmRMUWwx+TnkYAVeZSUWRKvw2e5D8OR/t4uPQ==",
 			"requires": {
 				"@rdfjs/formats-common": "^2.0.0",
 				"duplexify": "^3.6.1",
@@ -1318,6 +1318,22 @@
 				"barnard59-base": "0.0.1",
 				"rdf-parser-csvw": "^0.13.0",
 				"rdfxml-streaming-parser": "^1.2.0"
+			},
+			"dependencies": {
+				"barnard59-base": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/barnard59-base/-/barnard59-base-0.0.1.tgz",
+					"integrity": "sha512-nerc7N7xBMVKGOajbSi1yNXGawS6z02UAo79UhLOaA7/Nn9LbUF/IzxTivXc4fatb7dE4qM8yKaaeYTj+sbjNQ==",
+					"requires": {
+						"@rdfjs/formats-common": "^2.0.0",
+						"duplexify": "^3.6.1",
+						"nodeify-fetch": "^2.0.0",
+						"rdf-ext": "^1.1.2",
+						"rdf-transform-triple-to-quad": "^1.0.1",
+						"readable-stream": "^3.0.6",
+						"through2": "^2.0.3"
+					}
+				}
 			}
 		},
 		"barnard59-graph-store": {
@@ -7521,6 +7537,15 @@
 						"util-deprecate": "~1.0.1"
 					}
 				}
+			}
+		},
+		"through2-reduce": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/through2-reduce/-/through2-reduce-1.1.1.tgz",
+			"integrity": "sha1-QCv5qWQO//9RNpkbx9xyoqdnJRw=",
+			"requires": {
+				"through2": "~2.0.0",
+				"xtend": "~4.0.1"
 			}
 		},
 		"tmp": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "alcaeus": "^1.0.0-alpha.9",
     "aws-sdk": "^2.559.0",
     "barnard59": "^0.0.9",
+    "barnard59-base": "^0.0.3",
     "barnard59-formats": "0.0.6",
     "barnard59-graph-store": "^0.0.4",
     "clownface": "^0.12.1",
@@ -31,7 +32,8 @@
     "null-writable": "^1.0.5",
     "rdf-ext": "^1.3.0",
     "readable-stream": "^3.6.0",
-    "string-to-stream": "^3.0.1"
+    "string-to-stream": "^3.0.1",
+    "through2-reduce": "1.1.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "commander": "^4.1.1",
     "debug": "^4.1.1",
     "duplex-to": "1.0.0",
+    "get-stream": "5.1.0",
     "isstream": "^0.1.2",
     "null-writable": "^1.0.5",
     "rdf-ext": "^1.3.0",

--- a/packages/cli/pipelines/datacube-metadata.ttl
+++ b/packages/cli/pipelines/datacube-metadata.ttl
@@ -1,0 +1,38 @@
+@base <urn:pipeline:data-cube-curation> .
+@prefix : <https://pipeline.described.at/> .
+@prefix code: <https://code.described.at/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<#DatacubeMetadata> a :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList (
+    <#loadDatacubeMetadataStep>
+    <#parseDatacubeMetadata>
+    <#accumulateToDataset>
+    <#generateDatacubeMetadata>
+  ) ] .
+
+<#loadDatacubeMetadataStep> a :Step ;
+  code:implementedBy [
+    code:link <file:../lib/pipeline#asStep> ;
+    a code:EcmaScript
+  ] ;
+  code:arguments ( <#LoadDatacubeMetadata> ) .
+
+<#parseDatacubeMetadata> a :Step ;
+  code:implementedBy [
+    code:link <node:barnard59-formats#n3.parse> ;
+    a code:EcmaScript ;
+  ] .
+
+<#accumulateToDataset> a :Step ;
+  code:implementedBy [
+    code:link <file:../lib/datacube-metadata#accumulateToDataset> ;
+    a code:EcmaScript ;
+  ] .
+
+<#generateDatacubeMetadata> a :Step ;
+  code:implementedBy [
+    code:link <file:../lib/datacube-metadata#generate> ;
+    a code:EcmaScript ;
+  ] .

--- a/packages/cli/pipelines/from-filesystem.ttl
+++ b/packages/cli/pipelines/from-filesystem.ttl
@@ -4,12 +4,28 @@
 
 <#LoadCsv>
   :steps [ :stepList ( _:openCsvFromFilesystem ) ] ;
-  :variables [ :variable
-    [ a :Variable; :name "sourceDir"; :value "/input" ]
-  ].
+  :variables [ :variable <#sourceDir> ].
 
 _:openCsvFromFilesystem
   a                  :Step ;
   code:implementedBy [ code:link <file:../lib/csv#openFromCsvw> ;
                        a         code:EcmaScript ] ;
   code:arguments     ( "csvw"^^:VariableName "sourceDir"^^:VariableName ) .
+
+
+<#LoadDatacubeMetadata>
+  a :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList ( <#loadDatacubeMetadata> ) ] ;
+  :variables [ :variable <#sourceDir> ].
+
+<#loadDatacubeMetadata>
+  a :Step ;
+  code:implementedBy [
+    code:link <file:../lib/datacube-metadata#openFile> ;
+    a code:EcmaScript
+  ] ;
+  code:arguments ( "sourceDir"^^:VariableName ) .
+
+<#sourceDir> a :Variable ;
+  :name "sourceDir" ;
+  :value "/input" .

--- a/packages/cli/pipelines/from-s3.ttl
+++ b/packages/cli/pipelines/from-s3.ttl
@@ -18,3 +18,22 @@ _:openCsvFromBucket
                        "s3endpoint"^^:VariableName
                        "s3bucket"^^:VariableName
                      ) .
+
+<#LoadDatacubeMetadata>
+  a :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList ( <#loadDatacubeMetadata> ) ] ;
+  :variables [ :variable
+    [ a :Variable; :name "s3endpoint" ] ,
+    [ a :Variable; :name "s3bucket" ]
+  ].
+
+<#loadDatacubeMetadata>
+  a :Step ;
+  code:implementedBy [
+    code:link <file:../lib/datacube-metadata#openFileFromS3> ;
+    a code:EcmaScript
+  ] ;
+  code:arguments (
+    "s3endpoint"^^:VariableName
+    "s3bucket"^^:VariableName
+  ) .

--- a/packages/cli/pipelines/main.ttl
+++ b/packages/cli/pipelines/main.ttl
@@ -3,17 +3,22 @@
 @prefix code: <https://code.described.at/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-# ------------------------------
-#
-# Transform pipeline
-#
-# One-by-one parses and transforms the source csv files to RDF
-#
-# ------------------------------
+<#Main> a :Pipeline ;
+  :steps [ :stepList ( <#mergeInputs> <#linkObservationsToDataset> <#streamOutputStep> ) ] .
 
-<#TransformFiles>
-  a      :Pipeline ;
-  :steps [ :stepList ( <#loadMetadata> <#doTransform> <#streamOutputStep> ) ] .
+<#mergeInputs> a :Step ;
+  code:implementedBy [
+    code:link <node:barnard59-base#concat.object> ;
+    a code:EcmaScript
+  ] ;
+  code:arguments ( <#DatacubeMetadata> <#TransformFiles> ) .
+
+<#linkObservationsToDataset>
+  a :Step ;
+  code:implementedBy [
+    a code:EcmaScript ;
+    code:link <file:../lib/datacube-metadata#linkObservationsToDataset>
+  ] .
 
 <#StreamOutput>
   a :Pipeline, :WritableObjectMode .
@@ -23,6 +28,18 @@
   code:implementedBy [ code:link <file:../lib/pipeline#asStep> ;
                        a         code:EcmaScript ] ;
   code:arguments     ( <#StreamOutput> ) .
+
+# ------------------------------
+#
+# Transform pipeline
+#
+# One-by-one parses and transforms the source csv files to RDF
+#
+# ------------------------------
+
+<#TransformFiles>
+  a      :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList ( <#loadMetadata> <#doTransform> ) ] .
 
 <#loadMetadata>
   a                  :Step ;
@@ -78,4 +95,3 @@
                        code:link <node:barnard59-base#filter> ] ;
   code:arguments     ( [ code:link <file:../lib/output-filter#removeCsvwTriples> ;
                          a         code:EcmaScript ] ) .
-

--- a/packages/cli/typings/barnard59-core/lib/Pipeline.d.ts
+++ b/packages/cli/typings/barnard59-core/lib/Pipeline.d.ts
@@ -5,6 +5,7 @@ declare module 'barnard59-core/lib/Pipeline' {
   namespace Pipeline {
     interface Context {
       log: Logger;
+      variables: Map<any, any>;
     }
   }
 


### PR DESCRIPTION
Tries to find a file called `datacube-metadata.ttl` (either in S3 or filesystem, depending on the CLI options). Imports metadata from it and links everything together (DataSet -> Structure -> Components, DataSet -> Observations).

If the metadata file is not found, it will still generate the minimum viable metadata (DataSet, Structure, linked Observations) so that the data can be used. It won't generate a valid datacube that can be used in the visualization tool though.

The metadata file should look like the following:
```turtle
@base <http://ld.zazuko.com/blw/> .

@prefix qb: <http://purl.org/linked-data/cube#> .
@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@prefix scale: <http://ns.bergnet.org/cube/scale/> .
@prefix schema: <http://schema.org/> .
@prefix skos: <http://www.w3.org/2004/02/skos/core#> .

<dataset> a qb:DataSet ;
  rdfs:label "BLW dataset"@en ;
  rdfs:comment "The dataset description"@en .

# Measures

<price> a qb:MeasureProperty ;
  rdfs:label "Price"@en ;
  scale:scaleOfMeasure scale:Continuous ;
  rdfs:range xsd:decimal .

# Dimensions

<week-date> a qb:DimensionProperty ;
  rdfs:label "Calendar week"@en ;
  scale:scaleOfMeasure scale:Temporal ;
  rdfs:range xsd:date .

<currency> a qb:DimensionProperty ;
  rdfs:label "Currency"@en ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range xsd:string .

<value-creation-level> a qb:DimensionProperty ;
  rdfs:label "Value creation level"@en ;
  rdfs:label "Wertschoepfungstufe"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

<promotion-type> a qb:DimensionProperty ;
  rdfs:label "Promotion type"@en ;
  rdfs:label "Aktionstyp"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

<production-system> a qb:DimensionProperty ;
  rdfs:label "Production system"@en ;
  rdfs:label "Produktionssystem"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

<data-source> a qb:DimensionProperty ;
  rdfs:label "Data source"@en ;
  rdfs:label "Datenquelle"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

<sales-region> a qb:DimensionProperty ;
  rdfs:label "Sales region"@en ;
  rdfs:label "Verkaufsregion"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

<product-list> a qb:DimensionProperty ;
  rdfs:label "Product list"@en ;
  rdfs:label "Produktliste"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

<unit> a qb:DimensionProperty ;
  rdfs:label "Unit"@en ;
  rdfs:label "Einheit"@de ;
  scale:scaleOfMeasure scale:Nominal ;
  rdfs:range skos:Concept .

# Attributes

schema:identifier a qb:AttributeProperty ;
  rdfs:label "ID"@en ;
  rdfs:label "ID"@de .

rdfs:label a qb:AttributeProperty ;
  rdfs:label "Label"@en ;
  rdfs:label "Label"@de .

<language-key> a qb:AttributeProperty ;
  rdfs:label "Language key"@en ;
  rdfs:label "Language key"@de .
```