### PR TITLE
Clarify ReferenceAttributeForm wording and formatting

### DIFF
--- a/ui/src/components/project/ReferenceAttributeForm.vue
+++ b/ui/src/components/project/ReferenceAttributeForm.vue
@@ -10,7 +10,7 @@
         On table <TableTag :table="table" class="is-medium" />,
       </p>
       <p>
-        create a link to the <label for="referenced-table"><strong>category table</strong></label>
+        create a link to the <label for="referenced-table"><strong>dimension table</strong></label>
       </p>
       <b-field>
         <b-select v-model="attribute.referencedTableId" id="referenced-table">
@@ -24,8 +24,8 @@
 
       <div v-if="referencedTable" v-show="attribute.columnMapping.length > 0">
         <p>
-          The identifier <code>{{ referencedTable.identifierTemplate }}</code> shall use
-          the columns
+          The identifier <code>{{ referencedTable.identifierTemplate }}</code> will take
+          its values from the column{{ attribute.columnMapping.length === 1 ? '' : 's' }}
         </p>
         <table class="table columns-table">
           <tbody>
@@ -35,7 +35,7 @@
                   <option v-for="column in source.columns" :key="column.id" :value="column.id">{{ column.name }}</option>
                 </b-select>
               </td>
-              <td>for <code>{{ mapping.referencedColumnName }}</code></td>
+              <td>for <code>{{ '{' + mapping.referencedColumnName + '}' }}</code></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
I got a confused by the wording and formatting on this screen. *Shall* didn't look appropriate because we describe an intent, not a requirement. *Columns* was in plural form although there's only one column. Finally, the `<code>` formatting was giving the impression that in `foo/{bar}`, we would replace `bar` with something, while what we're really replacing is `{bar}`.

Here's an 'after' screenshot:

![Screen Shot 2020-03-10 at 16 28 02](https://user-images.githubusercontent.com/2022803/76329250-9cc23a80-62ec-11ea-920c-02f8bd381f7a.png)

There's something else I noticed on this screen but didn't change because I don't know in which direction to: *the **category table*** refers to a *dimension* table.