### PR TITLE
Replace csvw:datetime with csvw:dateTime

### DIFF
--- a/ui/src/datatypes.ts
+++ b/ui/src/datatypes.ts
@@ -15,7 +15,7 @@ export const all: DataTypeOption[] = [
   { name: 'binary', uri: 'xsd:base64Binary', kind: Kind.Any },
   { name: 'boolean', uri: 'xsd:boolean', kind: Kind.Any, params: [...defaultParams, 'format'] },
   { name: 'date', uri: 'xsd:date', kind: Kind.Date },
-  { name: 'datetime', uri: 'xsd:dateTime', kind: Kind.Date },
+  { name: 'dateTime', uri: 'xsd:dateTime', kind: Kind.Date },
   { name: 'dateTimeStamp', uri: 'xsd:dateTimeStamp', kind: Kind.Date },
   { name: 'decimal', uri: 'xsd:decimal', kind: Kind.Numeric },
   { name: 'integer', uri: 'xsd:integer', kind: Kind.Numeric },


### PR DESCRIPTION
I got confused when I tried to set the type of a column to `xsd:dateTime`, the suggestions usually show xsd types I am familiar with (eg. `dateTimeStamp`) but instead of `dateTime` it shows `datetime`.

According to [this](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#datatypes), `datetime` is defined as an alias for `dateTime`. The [CSVW Namespace Vocabulary](https://www.w3.org/ns/csvw#term-definitions) seems to confirm that both point to `xsd:dateTime`.

IMO displaying `dateTime` instead of `datetime` would be less confusing to people who are familiar with xsd datatypes but aren't familiar with CSVW aliases.