### PR TITLE
S3 getObject streams directly instead of loading whole body

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2224,6 +2224,11 @@
 			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
 			"dev": true
 		},
+		"duplex-to": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/duplex-to/-/duplex-to-1.0.0.tgz",
+			"integrity": "sha512-pjJ6/s31+3gmQzzeT9y19Xv+cXaYwOKlHJtucmfP2USyQ+oMGeijwEpIUViad5OLujVicJ8AxkkF6e7C2d//DQ=="
+		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,11 +26,12 @@
     "clownface": "^0.12.1",
     "commander": "^4.1.1",
     "debug": "^4.1.1",
-    "rdf-ext": "^1.3.0",
+    "duplex-to": "1.0.0",
     "isstream": "^0.1.2",
+    "null-writable": "^1.0.5",
+    "rdf-ext": "^1.3.0",
     "readable-stream": "^3.6.0",
-    "string-to-stream": "^3.0.1",
-    "null-writable": "^1.0.5"
+    "string-to-stream": "^3.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",


### PR DESCRIPTION
I debugged this locally and the whole body was loaded in memory. AWS SDK provides a way of directly streaming the request.

Error reporting is also a tiny bit better.