### PR TITLE
fix(ui): use relative API URL in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ADD ui/package.json ui/package-lock.json ./
 # Skip Cypress binary installation
 ENV CYPRESS_INSTALL_BINARY=0
 ENV NODE_ENV=
+ENV VUE_APP_API_URL=/
 RUN npm ci --unsafe-perm
 
 ADD ui ./
-ENV VUE_APP_API_URL=https://datacube.zazukoians.org/
 
 # build frontend
 ENV NODE_ENV=production

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3513,9 +3513,9 @@
       "dev": true
     },
     "alcaeus": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/alcaeus/-/alcaeus-0.10.6.tgz",
-      "integrity": "sha512-NF5Zq7CCx6R8bhPn+qxpumTMetftUf8VbN8NFm/iyDIVKA+qkAwTZ5aZsmKPdW7c+prXBMPhSC+jblz/XtGjjQ==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/alcaeus/-/alcaeus-0.10.7.tgz",
+      "integrity": "sha512-MNc5xqjM4rVdgq1pqcUeNMT6K7A1TgD2EcIVcn/iif5iJMCPDLZjeh4L5WReH+XrFjhfUehI/MzcN8Yhnt/3RA==",
       "requires": {
         "@rdfjs/parser-jsonld": "^1.1.1",
         "@rdfjs/serializer-jsonld": "^1.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
     "@fortawesome/vue-fontawesome": "^0.1.9",
     "@rdfjs/data-model": "1.1.2",
     "@zazuko/rdf-vocabularies": "2020.2.11",
-    "alcaeus": "0.10.6",
+    "alcaeus": "0.10.7",
     "buefy": "^0.8.12",
     "core-js": "^3.6.4",
     "debug": "^4.1.1",

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -38,6 +38,9 @@ rdf.resourceFactory.mixins.push(ColumnMixin)
 rdf.resourceFactory.mixins.push(ValueAttributeMixin)
 rdf.resourceFactory.mixins.push(ReferenceAttributeMixin)
 
+// Tells Hydra to use current browser location as base URI for relative URIs
+Hydra.baseUri = window.location.href
+
 export class APIError extends Error {
   details: any;
   response: IHydraResponse;


### PR DESCRIPTION
Use relative URL for API in production to avoid needing a specific build per deployment.

Fixes #89 

Requires a fix in Alcaeus to support relative URLs.