### PR TITLE
fix(cli): use relative filesystem paths

### DIFF
--- a/packages/cli/pipelines/from-filesystem.ttl
+++ b/packages/cli/pipelines/from-filesystem.ttl
@@ -5,7 +5,7 @@
 <#LoadCsv>
   :steps [ :stepList ( _:openCsvFromFilesystem ) ] ;
   :variables [ :variable
-    [ a :Variable; :name "sourceDir"; :value "/input" ]
+    [ a :Variable; :name "sourceDir"; :value "input" ]
   ].
 
 _:openCsvFromFilesystem

--- a/packages/cli/pipelines/to-filesystem.ttl
+++ b/packages/cli/pipelines/to-filesystem.ttl
@@ -6,7 +6,7 @@
   :steps     [ :stepList ( _:serialize _:save ) ] ;
   :variables [ :variable [ a      :Variable ;
                            :name  "targetFile" ;
-                           :value "/output/transformed.nt" ] ] .
+                           :value "output/transformed.nt" ] ] .
 
 _:serialize
   a                  :Step ;


### PR DESCRIPTION
I don't think it is meant to use absolute paths, is it?