### PR TITLE
ci(cli): added workflow to build CLI on github action

### DIFF
--- a/.github/workflows/cli-docker.yml
+++ b/.github/workflows/cli-docker.yml
@@ -1,0 +1,18 @@
+name: Build CLI docker image
+
+on:
+  push:
+    branches-ignore: master
+  pull_request:
+    branches: "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          dockerfile: cli.Dockerfile
+          push: false

--- a/packages/cli/lib/datacube-metadata.ts
+++ b/packages/cli/lib/datacube-metadata.ts
@@ -7,7 +7,7 @@ import $rdf from 'rdf-ext'
 import getStream from 'get-stream'
 import { Context } from 'barnard59-core/lib/Pipeline'
 import toReadable from 'barnard59-base/lib/toReadable'
-import { qb, rdf } from '@zazuko/rdfine-data-cube/namespaces'
+import { qb, rdf } from '@tpluscode/rdf-ns-builders'
 import * as S3 from './s3'
 
 const filename = 'datacube-metadata.ttl'


### PR DESCRIPTION
I noticed that the CLI docker image build would fail so I added a GitHub actions workflow.

Master excluded, because that is going to be built by docker hub anyway