### PR TITLE
fix(ui): show sources before tables are loaded

### DIFF
--- a/ui/src/views/project/Sources.vue
+++ b/ui/src/views/project/Sources.vue
@@ -25,13 +25,11 @@
       </div>
     </div>
 
-    <Loader :data="tables" v-slot="{ data: tables }">
-      <Loader :data="sources" v-slot="{ data: sources }" class="sources-list">
-          <SourceItem v-for="source in sources" :key="source.id" :project="project" :source="source" :tables="tables" :column-filter="columnFilter" />
-          <p v-if="sources.length < 1" class="has-text-grey">
-            No sources yet
-          </p>
-      </Loader>
+    <Loader :data="sources" v-slot="{ data: sources }" class="sources-list">
+        <SourceItem v-for="source in sources" :key="source.id" :project="project" :source="source" :tables="tables" :column-filter="columnFilter" />
+        <p v-if="sources.length < 1" class="has-text-grey">
+          No sources yet
+        </p>
     </Loader>
   </div>
 </template>


### PR DESCRIPTION
It will make everything a bit more janky, but it should still feel a bit faster since we have to load all the tables one by one and then all the attributes for each of them.