### PR TITLE
build(deps): update express-jwt

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5785,9 +5785,9 @@
       }
     },
     "express-jwt": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.3.tgz",
-      "integrity": "sha512-UdB8p5O8vGYTKm3SfREnLgVGIGEHcL3lrVyi3ebEX2qhMuagN623ju7ywWis+qYL+CXE7G1qPc2bCPBAg2MxZQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-6.0.0.tgz",
+      "integrity": "sha512-C26y9myRjx7CyhZ+BAT3p+gQyRCoDZ7qo8plCvLDaRT6je6ALIAQknT6XLVQGFKwIy/Ux7lvM2MNap5dt0T7gA==",
       "requires": {
         "async": "^1.5.0",
         "express-unless": "^0.3.0",

--- a/api/package.json
+++ b/api/package.json
@@ -50,7 +50,7 @@
     "express": "^4.17.1",
     "express-history-api-fallback": "^2.2.1",
     "express-http-problem-details": "^0.1.5",
-    "express-jwt": "^5.3.3",
+    "express-jwt": "^6",
     "http-problem-details": "^0.1.4",
     "http-problem-details-mapper": "^0.1.6",
     "hydra-box": "^0.4.2",


### PR DESCRIPTION
We've already been in the clear but this patches a potential vulnerability [GHSA-6g6m-m6h5-w9gf](https://github.com/advisories/GHSA-6g6m-m6h5-w9gf)