### PR TITLE
Authenticate API calls in CLI

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -37,6 +37,10 @@ async function main () {
     .option('-v, --variable <name=value>', 'Pipeline variables', parseVariables, new Map())
     .option('--debug', 'Print diagnostic information to standard output')
     .option('--enable-buffer-monitor', 'enable histogram of buffer usage')
+    .option('--issuer <url>', 'OpenID Connect provider to authenticate against')
+    .option('--client-id <clientId>', 'Client ID to use to authenticate API calls')
+    .option('--client-secret <clientSecret>', 'Client secret to use to authenticate API calls')
+    .option('--auth-param <name=value>', 'Additional variables to pass to the token endpoint', parseVariables, new Map())
     .action(transform(pipelines.TransformFiles, __dirname, log))
 
   return program.parseAsync(process.argv)

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -37,9 +37,9 @@ async function main () {
     .option('-v, --variable <name=value>', 'Pipeline variables', parseVariables, new Map())
     .option('--debug', 'Print diagnostic information to standard output')
     .option('--enable-buffer-monitor', 'enable histogram of buffer usage')
-    .option('--issuer <url>', 'OpenID Connect provider to authenticate against')
-    .option('--client-id <clientId>', 'Client ID to use to authenticate API calls')
-    .option('--client-secret <clientSecret>', 'Client secret to use to authenticate API calls')
+    .option('--auth-issuer <url>', 'OpenID Connect provider to authenticate against')
+    .option('--auth-client-id <clientId>', 'Client ID to use to authenticate API calls')
+    .option('--auth-client-secret <clientSecret>', 'Client secret to use to authenticate API calls')
     .option('--auth-param <name=value>', 'Additional variables to pass to the token endpoint', parseVariables, new Map())
     .action(transform(pipelines.TransformFiles, __dirname, log))
 

--- a/packages/cli/lib/auth.ts
+++ b/packages/cli/lib/auth.ts
@@ -1,0 +1,101 @@
+import fetch from 'node-fetch'
+import { Debugger } from 'debug'
+import querystring from 'querystring'
+import Hydra from 'alcaeus'
+
+let log: Debugger
+
+export type AuthConfig = {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  params: Map<string, string>;
+}
+
+type Metadata = {
+  token_endpoint: string;
+}
+
+type Token = {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+}
+
+type LiveToken = Token & {
+  expiration: number;
+}
+
+function isValid (token: LiveToken) {
+  return token.expiration > Date.now() + 60 * 1000
+}
+
+let metadata: Metadata | null = null
+async function getMetadata (config: AuthConfig): Promise<Metadata> {
+  if (!metadata) {
+    const response = await fetch(
+      `${config.issuer}/.well-known/openid-configuration`
+    )
+    metadata = (await response.json()) as Metadata
+  }
+  return metadata
+}
+
+let token: LiveToken | null = null
+async function getToken (config: AuthConfig): Promise<LiveToken> {
+  if (!token || !isValid(token)) {
+    const m = await getMetadata(config)
+
+    const params = {}
+    params['grant_type'] = 'client_credentials'
+    params['client_id'] = config.clientId
+    params['client_secret'] = config.clientSecret
+
+    config.params.forEach((value, key) => (params[key] = value))
+
+    const response = await fetch(m['token_endpoint'], {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: querystring.stringify(params),
+    })
+
+    const t = (await response.json()) as Token
+
+    if (t['error']) {
+      throw new Error(t['error_description'] || t['error'])
+    }
+
+    log('Renewed access token', t)
+
+    const expiration = Date.now() + t.expires_in * 1000
+    token = {
+      ...t,
+      expiration,
+    }
+  }
+
+  return token
+}
+
+async function renew (config: AuthConfig) {
+  const t = await getToken(config)
+  Hydra.defaultHeaders = {
+    Authorization: `Bearer ${t['access_token']}`,
+  }
+}
+
+let interval: NodeJS.Timeout | null = null
+export function stopRenewing () {
+  if (interval) {
+    clearInterval(interval)
+    interval = null
+  }
+}
+
+export async function setupAuthentication (config: AuthConfig, log_: Debugger) {
+  log = log_
+  await renew(config)
+  interval = setInterval(() => renew(config), 1000)
+}

--- a/packages/cli/lib/commands/transform.ts
+++ b/packages/cli/lib/commands/transform.ts
@@ -17,9 +17,9 @@ interface RunOptions extends Command {
   project: string;
   variable: Map<string, string>;
   enableBufferMonitor: boolean;
-  issuer?: string;
-  clientId: string;
-  clientSecret: string;
+  authIssuer?: string;
+  authClientId: string;
+  authClientSecret: string;
   authParam: Map<string, string>;
 }
 
@@ -29,11 +29,11 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
 
     log.enabled = debug
 
-    if (command.issuer) {
+    if (command.authIssuer) {
       const authConfig: AuthConfig = {
-        issuer: command.issuer,
-        clientId: command.clientId,
-        clientSecret: command.clientSecret,
+        issuer: command.authIssuer,
+        clientId: command.authClientId,
+        clientSecret: command.authClientSecret,
         params: command.authParam,
       }
 

--- a/packages/cli/lib/commands/transform.ts
+++ b/packages/cli/lib/commands/transform.ts
@@ -6,7 +6,7 @@ import cf from 'clownface'
 import { fileToDataset } from 'barnard59'
 import { Pipeline } from '../pipeline-model/Pipeline'
 import { Debugger } from 'debug'
-import { AuthConfig, setupAuthentication, stopRenewing } from '../auth'
+import { AuthConfig, setupAuthentication } from '../auth'
 import Runner = require('barnard59/lib/runner')
 const bufferDebug = require('barnard59/lib/bufferDebug')
 
@@ -29,6 +29,7 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
 
     log.enabled = debug
 
+    let stopRenewing: () => void | undefined
     if (command.authIssuer) {
       const authConfig: AuthConfig = {
         issuer: command.authIssuer,
@@ -37,7 +38,7 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
         params: command.authParam,
       }
 
-      await setupAuthentication(authConfig, log)
+      stopRenewing = await setupAuthentication(authConfig, log)
     }
 
     const pipelinePath = filename => path.join(basePath, `./pipelines/${filename}.ttl`)
@@ -67,6 +68,6 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
       bufferDebug(run.pipeline)
     }
 
-    return run.promise.finally(stopRenewing)
+    return run.promise.finally(() => stopRenewing && stopRenewing())
   }
 }

--- a/packages/cli/lib/project.ts
+++ b/packages/cli/lib/project.ts
@@ -81,6 +81,7 @@ class ProjectIterator extends stream.Readable {
 
         return Promise.all(loadMetadata)
       })
+      .catch(e => this.emit('error', e))
       .finally(() => {
         this.push(null)
       })

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -730,6 +730,12 @@
 				}
 			}
 		},
+		"@types/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@types/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-cnEvTAVVRqF6OQg/4SLnbxQ0slZJHqZQDve5BzGhcIQtuMpPv8T5QNS2cBPa/W0jTxciqwn7bmJAIGe/bOJ5Kw==",
+			"dev": true
+		},
 		"@types/rdf-ext": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/rdf-ext/-/rdf-ext-1.3.5.tgz",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -707,6 +707,29 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
 			"integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
 		},
+		"@types/node-fetch": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+			"integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"form-data": "^3.0.0"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
+				}
+			}
+		},
 		"@types/rdf-ext": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/rdf-ext/-/rdf-ext-1.3.5.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
     "postinstall": "mkdir -p input; mkdir -p output",
     "precommit": "lint-staged",
     "transform": "dotenv -- yarn start",
-    "start": "ts-node index.ts transform --from s3 --project \"$TRANSFORM_PROJECT\" --debug --enable-buffer-monitor -v s3endpoint=$S3_ENDPOINT -v s3bucket=$S3_BUCKET -v graph-store-endpoint=$GRAPH_STORE_ENDPOINT -v graph-store-user=$GRAPH_STORE_USER -v graph-store-password=$GRAPH_STORE_PASSWORD -v graph=$TRANSFORM_GRAPH",
+    "start": "ts-node index.ts transform --from s3 --project \"$TRANSFORM_PROJECT\" --debug --enable-buffer-monitor -v s3endpoint=$S3_ENDPOINT -v s3bucket=$S3_BUCKET -v graph-store-endpoint=$GRAPH_STORE_ENDPOINT -v graph-store-user=$GRAPH_STORE_USER -v graph-store-password=$GRAPH_STORE_PASSWORD -v graph=$TRANSFORM_GRAPH --auth-issuer $AUTH_ISSUER --auth-client-id $AUTH_CLIENT_ID --auth-client-secret $AUTH_CLIENT_SECRET",
     "build": "tsc"
   },
   "dependencies": {
@@ -32,6 +32,7 @@
     "get-stream": "5.1.0",
     "isstream": "^0.1.2",
     "null-writable": "^1.0.5",
+    "once": "^1.4.0",
     "rdf-ext": "^1.3.0",
     "readable-stream": "^3.6.0",
     "string-to-stream": "^3.0.1",
@@ -42,6 +43,7 @@
     "@types/debug": "^4.1.5",
     "@types/isstream": "^0.1.0",
     "@types/node-fetch": "^2.5.7",
+    "@types/once": "^1.4.0",
     "@types/rdf-ext": "^1.3.5",
     "@types/rdf-js": "^2.0.11",
     "@types/rdfjs__formats-common": "^2.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@types/clownface": "^0.12.10",
     "@types/debug": "^4.1.5",
     "@types/isstream": "^0.1.0",
+    "@types/node-fetch": "^2.5.7",
     "@types/rdf-ext": "^1.3.5",
     "@types/rdf-js": "^2.0.11",
     "@types/rdfjs__formats-common": "^2.0.0",

--- a/packages/rdfine-data-cube/package-lock.json
+++ b/packages/rdfine-data-cube/package-lock.json
@@ -3894,68 +3894,6 @@
 				}
 			}
 		},
-		"@rdf-esm/data-model": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@rdf-esm/data-model/-/data-model-0.5.3.tgz",
-			"integrity": "sha512-3LEd0RCWNykk10fDEVqfasikjLeDxeaFYWmF86D+f4pmhAUD7r+4RstGW7Lgcd0zOfjxMCx+ZRLQf3Etwfrz7g==",
-			"requires": {
-				"@rdfjs/data-model": "^1.1.2"
-			}
-		},
-		"@rdf-esm/namespace": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@rdf-esm/namespace/-/namespace-0.5.1.tgz",
-			"integrity": "sha512-n6aJy2uAu/r4VeC73Mts3mOvKl2tZ34AJHD8St6RtlSAneX4/PjXSwpX5F14Tiqc46RaXbIDBryDdhG/UrYbkQ==",
-			"requires": {
-				"@rdf-esm/data-model": "^0.5.1",
-				"@rdfjs/namespace": "^1.1.0"
-			}
-		},
-		"@rdfine/csvw": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@rdfine/csvw/-/csvw-0.2.11.tgz",
-			"integrity": "sha512-RmQrrDNuHZIHcujM/E/Uy572UtYIy35QNf9akf/0qtJdwnCG6/qc2hFWj/qiSfhQHcL1e1Q5gM/Q9ImYFo6HKA==",
-			"requires": {
-				"@rdfjs/namespace": "^1.1.0",
-				"@tpluscode/rdf-ns-builders": "^0.1.0",
-				"@tpluscode/rdfine": "^0.4.12",
-				"esm": "^3.2.25"
-			},
-			"dependencies": {
-				"@tpluscode/rdfine": {
-					"version": "0.4.20",
-					"resolved": "https://registry.npmjs.org/@tpluscode/rdfine/-/rdfine-0.4.20.tgz",
-					"integrity": "sha512-P87z/oi6aqidwVLvtOAIRRTk7Xx1pzr8LAqsvkyCOSAayiwEZ6lojxBtD449/nvP5OxNg61ZsvOT4tG5VDc84w==",
-					"requires": {
-						"@rdfjs/data-model": "^1.1.2",
-						"@rdfjs/namespace": "^1.1.0",
-						"@rdfjs/term-set": "^1.0.1",
-						"@tpluscode/rdf-ns-builders": "^0.3.6",
-						"clownface": "^0.12.3",
-						"once": "^1.4.0"
-					},
-					"dependencies": {
-						"@tpluscode/rdf-ns-builders": {
-							"version": "0.3.7",
-							"resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-0.3.7.tgz",
-							"integrity": "sha512-WyLjL2RNtHgipOwHbyA042KUYeVfF5X1Wz+SL+3QQODXCmqsDOAwVatthkJRD7uAs26SiyBmlejFSYV9PD0AVw==",
-							"requires": {
-								"@rdf-esm/namespace": "^0.5.1"
-							}
-						}
-					}
-				},
-				"clownface": {
-					"version": "0.12.4",
-					"resolved": "https://registry.npmjs.org/clownface/-/clownface-0.12.4.tgz",
-					"integrity": "sha512-Y2SSy8pME3gg79sDoIj1AYUlrQNoq19DfEfiu7S4wv3R6P+wlXXhDmq7I78SOnYglwJudqhh7FgLbMMx//+ryw==",
-					"requires": {
-						"@rdfjs/data-model": "^1.1.0",
-						"@rdfjs/namespace": "^1.0.0"
-					}
-				}
-			}
-		},
 		"@rdfjs/data-model": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
@@ -3987,14 +3925,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
 			"integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA=="
-		},
-		"@rdfjs/term-set": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.0.1.tgz",
-			"integrity": "sha512-7+pSdm8R1nhSyP1xEqcQYFTARD/2iLr98tiAsSUfykCg0T0LrZ6j/3EEKmcKTWLMazMA9deRfmjPvzqMFwLBig==",
-			"requires": {
-				"@rdfjs/to-ntriples": "^1.0.2"
-			}
 		},
 		"@rdfjs/to-ntriples": {
 			"version": "1.0.2",


### PR DESCRIPTION
This makes the CLI authenticate using the `client_credentials` grant.

This adds 4 flags, to specify the IdP, the client id/secret as well as arbitrary params added to the token request. This is useful when working with providers like Auth0, who need additional params to get proper JWT tokens

Because the access token can be short-lived (5min by default on Keycloak), I needed to have a renew mechanism. It is based on `setInterval`, because the `Hydra.defaultHeaders` method isn't async (maybe that could be a thing @tpluscode?)

Not sure how I'm supposed to test a pipeline, but locally I was able to run it without having 401 errors popping in the logs