### PR TITLE
refactor: use async function to set auth headers

### DIFF
--- a/packages/cli/lib/commands/transform.ts
+++ b/packages/cli/lib/commands/transform.ts
@@ -29,7 +29,6 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
 
     log.enabled = debug
 
-    let stopRenewing: () => void | undefined
     if (command.authIssuer) {
       const authConfig: AuthConfig = {
         issuer: command.authIssuer,
@@ -38,7 +37,7 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
         params: command.authParam,
       }
 
-      stopRenewing = await setupAuthentication(authConfig, log)
+      setupAuthentication(authConfig, log)
     }
 
     const pipelinePath = filename => path.join(basePath, `./pipelines/${filename}.ttl`)
@@ -68,6 +67,6 @@ export default function (pipelineId: NamedNode, basePath: string, log: Debugger)
       bufferDebug(run.pipeline)
     }
 
-    return run.promise.finally(() => stopRenewing && stopRenewing())
+    return run.promise
   }
 }


### PR DESCRIPTION
Goodbye `setInterval`