### PR TITLE
Fix the AUTH_CONFIG_FILE not being read

### DIFF
--- a/api/frontend.ts
+++ b/api/frontend.ts
@@ -24,14 +24,13 @@ export function uiConfig (req, res) {
     const stream = fs.createReadStream(env.AUTH_CONFIG_FILE)
     stream.pipe(res)
   } else {
-    res.write(`
+    res.send(`
 window.oidc = {
   authority: '${env.AUTH_ISSUER}',
   clientId: '${env.AUTH_CLIENT_ID}',
   scope: 'profile pipelines:read pipelines:write',
 }`)
   }
-  res.end()
 }
 
 export default app


### PR DESCRIPTION
The `/env-config.js` endpoint called `res.end` even though we were piping a stream, which broke everything. This does not impact simple setups (like all our production ones) but it prevents the app from working with providers like dex.