### PR TITLE
fix: ui should automatically renew auth token

### DIFF
--- a/ui/src/store/modules/oidc.ts
+++ b/ui/src/store/modules/oidc.ts
@@ -3,6 +3,7 @@ import { vuexOidcCreateStoreModule } from 'vuex-oidc'
 export const oidc = () => vuexOidcCreateStoreModule({
   redirectUri: window.location.origin + '/app/oidc-callback',
   responseType: 'code',
+  automaticSilentRenew: true,
   ...window.oidc,
 }, {
   routeBase: '/app/',


### PR DESCRIPTION
Enabling opt-in setting of `vuex-oidc` to automatically renew auth tokens.